### PR TITLE
fill the search quota by measuring instead of assuming a rate

### DIFF
--- a/src/llm_utils.py
+++ b/src/llm_utils.py
@@ -31,13 +31,33 @@ DEFAULT_USER_PROMPT_FOR_SEARCH_POINTS_WITHOUT_DESC = """Generate the first searc
 
 USER_PROMPT_FOR_SEARCH_QUERY_CONTINUATION = """Generate the next search query."""
 
+# Without an explicit timeout a stalled or cold ollama backend blocks the whole
+# run forever, which is fatal for an unattended scheduled run.
+_CLIENT = ollama.Client(timeout=180)
+
+MAX_EMPTY_RETRIES = 5
+
+
 def get_ollama_response(messages: list[dict[str, str]], model: str="gemma4:cloud") -> str:
-	response = ollama.chat(
+	response = _CLIENT.chat(
 		model=model,
 		messages=messages
 	)
 
 	return response.message.content
+
+
+def get_nonempty_ollama_response(messages: list[dict[str, str]]) -> str:
+	"""Retry a bounded number of times instead of spinning forever on empties."""
+	for attempt in range(MAX_EMPTY_RETRIES):
+		response = get_ollama_response(messages)
+
+		if response and response.strip():
+			return response
+
+		print(f"[WARNING] Empty LLM response, retry {attempt + 1}/{MAX_EMPTY_RETRIES}")
+
+	raise RuntimeError(f"LLM returned nothing usable after {MAX_EMPTY_RETRIES} attempts")
 
 def get_search_query_from_task_description(task_description: str) -> str:
 	# compat
@@ -54,7 +74,7 @@ def get_search_query_from_task_description(task_description: str) -> str:
 		}
 	]
 
-	while not (response := get_ollama_response(messages)): pass # ensure non-empty response
+	response = get_nonempty_ollama_response(messages)
 
 	return response.lower()
 
@@ -71,7 +91,7 @@ def get_related_search_queries(seed_word: str, num_queries: int=20) -> Generator
 	]
 
 	for _ in range(num_queries):
-		while not (response := get_ollama_response(messages)): pass # ensure non-empty response
+		response = get_nonempty_ollama_response(messages)
 
 		yield response.lower()
 

--- a/src/rewards_tasks.py
+++ b/src/rewards_tasks.py
@@ -154,14 +154,57 @@ class RewardsTaskUtils:
 		for i in range(scroll_times):
 			ActionChains(self.driver).scroll_by_amount(0, -100).perform() # scroll back to top of page
 
-	def complete_required_searches(self):
+	def complete_required_searches(self, max_rounds: int = 6):
+		# Points per search are not fixed. Some markets award 3 rather than 5,
+		# the daily maximum itself changes (observed 15, 30 and 60 on the same
+		# account within one day, with the counter resetting), and daily set and
+		# card searches count towards the same quota. A single up front division
+		# therefore leaves points on the table and still reports success.
+		# Measure, search, measure again.
+		points_earned, max_pts = self.read_search_points()
+
+		print(f"[INFO] Search points before: {points_earned}/{max_pts}")
+
+		for round_number in range(1, max_rounds + 1):
+			if points_earned >= max_pts:
+				break
+
+			# Assume the lower known rate so a round never overshoots by much.
+			searches = max(1, (max_pts - points_earned) // 3)
+
+			self.run_search_batch(searches)
+
+			previous = points_earned
+			points_earned, max_pts = self.read_search_points()
+
+			print(f"[INFO] Round {round_number}: {searches} searches -> {points_earned}/{max_pts}")
+
+			if points_earned <= previous:
+				print("[WARNING] Round produced no points, stopping instead of searching pointlessly.")
+				break
+
+		if points_earned < max_pts:
+			print(f"[WARNING] Search quota not filled: {points_earned}/{max_pts}")
+		else:
+			print(f"Search quota complete: {points_earned}/{max_pts}")
+
+	def read_search_points(self):
+		"""Open the points breakdown, read the Bing search row, close it again."""
 		self.switch_to_earn_page()
 		self.wait_for_then_click(self.elements.get_points_breakdown_button)
-		self.wait_for_element(self.elements.get_close_button_on_points_breakdown) # make sure sidebar loads
+
+		close_btn = self.wait_for_element(self.elements.get_close_button_on_points_breakdown)
 
 		points_earned, max_pts = self.elements.get_points_earned_from_searches_on_points_breakdown()
-		searches_needed = (max_pts - points_earned) // 5
 
+		try:
+			self.move_to_and_click(close_btn)
+		except Exception:
+			pass
+
+		return points_earned, max_pts
+
+	def run_search_batch(self, count: int):
 		self.driver.get("https://www.bing.com/")
 		self.tab_utils.ensure_focus()
 
@@ -171,7 +214,7 @@ class RewardsTaskUtils:
 
 		for i, query in enumerate(
 			llm_utils.get_related_search_queries(
-				llm_utils.get_random_noun(), num_queries=searches_needed
+				llm_utils.get_random_noun(), num_queries=count
 			)
 		):
 			self.keyboard.send_keys(query+Keys.ENTER)
@@ -185,18 +228,6 @@ class RewardsTaskUtils:
 
 		self.driver.get("https://rewards.bing.com/")
 		self.tab_utils.ensure_focus()
-
-		self.switch_to_earn_page()
-
-		self.wait_for_then_click(self.elements.get_points_breakdown_button)
-
-		close_btn = self.wait_for_element(self.elements.get_close_button_on_points_breakdown)
-
-		points_earned, max_pts = self.elements.get_points_earned_from_searches_on_points_breakdown()
-
-		self.move_to_and_click(close_btn)
-
-		print(f"Points earned from {searches_needed} searches: {points_earned}/{max_pts}")
 
 	def claim_bonus_points(self):
 		self.switch_to_dashboard()


### PR DESCRIPTION
Follow-up from #4, opened on request. `complete_required_searches` computes the number of searches once and never checks whether they were enough:

```python
searches_needed = (max_pts - points_earned) // 5
```

Two assumptions in that line fail in practice.

**The rate is not 5 everywhere.** My market credits about 3 points per search. The run did roughly half the needed searches, stopped at 18/30, and still printed a success line.

**The maximum is not stable either.** On one account within a single day the Bing search row read `x/15`, then `x/30`, then `x/60`, and the earned counter reset when the cap changed. Any constant is wrong sooner or later. The daily set and card clicks also count towards the same quota, which shifts the starting point before this task even runs.

## Change

Measure, search, measure again:

- read the Bing search row from the points breakdown
- run a batch sized on the lower known rate, so a round never overshoots by much
- re-read, repeat until the quota is full, a round gains nothing, or `max_rounds` is hit
- print `[WARNING] Search quota not filled` instead of a success line when it ends short

The batch itself is the existing search code unchanged, just moved into `run_search_batch` so the loop can call it.

Second thing, small but load-bearing for scheduled runs: the ollama client now has a 180s timeout and the empty-response retry is bounded at 5. Both were unbounded before. I had an unattended run hang for 14 minutes with 2.3 CPU-seconds total, no output, while `ollama ps` showed no model loaded, and `while not (response := ...): pass` spins forever if the model keeps returning empties. The default model is untouched.

## Verification

This exact loop ran in production on my fork today, with the only difference being a local model name in the default parameter:

```
[INFO] Search points before: 18/30
[INFO] Round 1: 4 searches -> 27/30
[INFO] Round 2: 1 searches -> 30/30
Search quota complete: 30/30
```

and after the cap changed to 60 later the same day:

```
[INFO] Search points before: 3/60
[INFO] Round 1: 19 searches -> 60/60
Search quota complete: 60/60
```

On this branch it compiles; I could not end-to-end run it here because I use a local model rather than `gemma4:cloud`.

Touches the same file as #4 but a different method, so the two merge cleanly in either order.
