### PR TITLE
drive the misc cards scrolling with wheel input instead of fixed bursts

### DIFF
--- a/src/mouse_trajectory.py
+++ b/src/mouse_trajectory.py
@@ -311,6 +311,57 @@ class MouseUtils:
 					self.driver.execute_script(f"window.moveVisualCursor({point[0]}, {point[1]});")
 
 
+	def wheel_scroll_element_into_view(self, element: WebElement, max_wheel_events: int = 60):
+		"""Scroll the element into the viewport with simulated wheel input.
+
+		Wheel steps of varying size with short pauses, the way a person scrolls,
+		instead of a fixed-size burst. The loop is bounded on purpose: an element
+		that never fits the viewport completely, for example one taller than the
+		window, must not hang the run forever. When the budget runs out the
+		caller proceeds with the element as visible as it got.
+		"""
+		for _ in range(max_wheel_events):
+			top, bottom, height = self.driver.execute_script(
+				"var r = arguments[0].getBoundingClientRect();"
+				"return [r.top, r.bottom, window.innerHeight];",
+				element
+			)
+
+			if top >= 0 and bottom <= height:
+				break
+
+			# Aim the element at the middle of the viewport, one notch at a time.
+			distance = (top + bottom) / 2 - height / 2
+			step = max(-320, min(320, distance))
+			step = int(step * random.uniform(0.6, 1.0))
+
+			if abs(step) < 40:
+				step = 40 if distance > 0 else -40
+
+			ActionChains(self.driver).scroll_by_amount(0, step).perform()
+
+			time.sleep(random.uniform(0.04, 0.12))
+
+	def wheel_scroll_to_top(self, max_wheel_events: int = 80):
+		"""Scroll back to the top of the page with simulated wheel input.
+
+		Reads the actual scroll position instead of unwinding a counted number
+		of steps, because the page height can change while cards update and a
+		symmetric unwind then lands in the wrong place.
+		"""
+		for _ in range(max_wheel_events):
+			offset = self.driver.execute_script("return window.scrollY || window.pageYOffset;")
+
+			if offset <= 0:
+				break
+
+			step = min(340, int(offset))
+			step = max(60, int(step * random.uniform(0.6, 1.0)))
+
+			ActionChains(self.driver).scroll_by_amount(0, -step).perform()
+
+			time.sleep(random.uniform(0.04, 0.12))
+
 	def move_to_element(self, element: WebElement, visualize: bool=True):
 		# The pointer is moved to viewport coordinates, so an element below the
 		# fold yields a target outside the window and the driver rejects the move

--- a/src/rewards_tasks.py
+++ b/src/rewards_tasks.py
@@ -7,7 +7,6 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webelement import WebElement
-from selenium.webdriver.common.action_chains import ActionChains
 from selenium.common.exceptions import StaleElementReferenceException, TimeoutException, NoSuchElementException
 import tab_utils
 import llm_utils
@@ -140,12 +139,8 @@ class RewardsTaskUtils:
 
 		misc_cards: list[WebElement] = self.wait_for_element(self.elements.get_all_misc_cards)
 
-		scroll_times = 0
-
 		for card in misc_cards:
-			while not self.elements.element_is_fully_in_viewport(card): # this should work for top-down iteration
-				ActionChains(self.driver).scroll_by_amount(0, 100).perform()
-				scroll_times+=1
+			self.mouse.wheel_scroll_element_into_view(card)
 
 			if not self.elements.card_is_complete(card) and self.elements.get_card_point_value(card) > 0:
 				self.move_to_and_click(card)
@@ -158,8 +153,7 @@ class RewardsTaskUtils:
 
 		self.tab_utils.close_all_other_tabs()
 
-		for i in range(scroll_times):
-			ActionChains(self.driver).scroll_by_amount(0, -100).perform() # scroll back to top of page
+		self.mouse.wheel_scroll_to_top()
 
 	def complete_required_searches(self, max_rounds: int = 6):
 		# Points per search are not fixed. Some markets award 3 rather than 5,


### PR DESCRIPTION
The separate PR you suggested in #4 for the misc cards scrolling.

## What was wrong with it

Three things, one visible and two waiting to bite:

1. The card loop fired fixed 100px scroll events back to back with no pauses. That is the jumpy scrolling you saw.
2. The `while not element_is_fully_in_viewport(card)` loop had no bound. A card that never fits the viewport completely, for example on a small window, scrolls forever and hangs the run. Same family as the crashes in #6.
3. The way back up replayed a counted number of steps in reverse. When the page height changes while card statuses update, the count no longer matches and it lands in the wrong place.

## What it does now

Two helpers on `MouseUtils`, used by `complete_misc_cards`:

- `wheel_scroll_element_into_view` sends wheel input with varying step sizes and short pauses, aimed at centering the target, bounded at 60 events. If the element never fits completely, the loop ends and the caller proceeds with it as visible as it got instead of hanging.
- `wheel_scroll_to_top` reads the actual scroll position and steps back up until it reaches 0, also with varied steps and pauses, instead of counting.

The pointer move from #4 checks visibility before it scrolls, so after the wheel brings a card into view there is no second scroll on top.

The now unused `ActionChains` import in `rewards_tasks.py` is removed with it.

## Verification

Ran `complete_misc_cards` live against the earn page with 8 cards, all of them already completed today, so the run scrolls through every card, clicks nothing, and returns:

```
scrollY start=0  end=0  duration=6.4s
```

Wheel path down through all cards, clean return to the top, no exception.
