### PR TITLE
switch the bot runtime from print to logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.png
 *.txt
+*.log
 !nouns.txt
 Todo.md
 data-dir/

--- a/README.md
+++ b/README.md
@@ -48,4 +48,25 @@ EU Users: you may have to accept a consent banner once on `rewards.bing.com` and
 
 Close all webdriver browser instances. Run `main.py` again; the automation should start working.
 
+# Logging
+
+The script logs to the console. Two optional environment variables change that:
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `REWARDS_FARMER_LOG_LEVEL` | `INFO` | Set to `DEBUG` to also attach the full stack trace to every `[FAIL]` line. |
+| `REWARDS_FARMER_LOG_FILE` | unset | Path to also write the log to, useful for unattended runs. |
+
+Windows (PowerShell)
+```sh
+$env:REWARDS_FARMER_LOG_LEVEL="DEBUG"; $env:REWARDS_FARMER_LOG_FILE="run.log"; python src/main.py
+```
+
+*nix (Bash)
+```sh
+REWARDS_FARMER_LOG_LEVEL=DEBUG REWARDS_FARMER_LOG_FILE=run.log python src/main.py
+```
+
+If you are opening an issue about a crash, running with `REWARDS_FARMER_LOG_LEVEL=DEBUG` and attaching the log is the most useful thing you can include.
+
 Please open up a GitHub issue if you run into any difficulties.

--- a/src/llm_utils.py
+++ b/src/llm_utils.py
@@ -1,6 +1,9 @@
 from typing import Generator
+import logging
 import random
 import ollama
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_SYSTEM_PROMPT_FOR_SEARCH_QUEST = (
 	"You are a helpful assistant tasked with creating a search query based on a directive. "
@@ -55,7 +58,7 @@ def get_nonempty_ollama_response(messages: list[dict[str, str]]) -> str:
 		if response and response.strip():
 			return response
 
-		print(f"[WARNING] Empty LLM response, retry {attempt + 1}/{MAX_EMPTY_RETRIES}")
+		logger.warning("Empty LLM response, retry %s/%s", attempt + 1, MAX_EMPTY_RETRIES)
 
 	raise RuntimeError(f"LLM returned nothing usable after {MAX_EMPTY_RETRIES} attempts")
 

--- a/src/log_utils.py
+++ b/src/log_utils.py
@@ -1,0 +1,90 @@
+"""Central logging configuration.
+
+`setup_logging` is called once from `main.py`. Every other module just does
+`logger = logging.getLogger(__name__)` at import time, which is safe to do
+before this runs, so import order does not matter.
+"""
+
+import logging
+import os
+import sys
+
+LEVEL_ENV_VAR = "REWARDS_FARMER_LOG_LEVEL"
+FILE_ENV_VAR = "REWARDS_FARMER_LOG_FILE"
+
+DEFAULT_LEVEL = "INFO"
+
+# CRITICAL is the longest level name at 8 characters, so pad to that and the
+# message column stays aligned no matter what is being logged.
+LOG_FORMAT = "%(asctime)s %(levelname)-8s %(name)s: %(message)s"
+DATE_FORMAT = "%H:%M:%S"
+
+_configured = False
+
+
+def _resolve_level(level: str | int | None) -> int:
+	"""Turn a level name, a level number or None into a level number.
+
+	An unusable value falls back to the default rather than raising. A typo in
+	an environment variable must not be able to take down an unattended run.
+	"""
+	if level is None:
+		level = os.environ.get(LEVEL_ENV_VAR, DEFAULT_LEVEL)
+
+	if isinstance(level, int):
+		return level
+
+	resolved = logging.getLevelNamesMapping().get(str(level).strip().upper())
+
+	if resolved is None:
+		logging.getLogger(__name__).warning(
+			"Unknown log level %r, falling back to %s", level, DEFAULT_LEVEL
+		)
+
+		return logging.getLevelNamesMapping()[DEFAULT_LEVEL]
+
+	return resolved
+
+
+def setup_logging(level: str | int | None = None, log_file: str | None = None) -> None:
+	"""Configure the root logger. Calling this more than once is a no-op.
+
+	`level` defaults to $REWARDS_FARMER_LOG_LEVEL, then to INFO.
+	`log_file` defaults to $REWARDS_FARMER_LOG_FILE, and no file is written
+	when neither is set.
+	"""
+	global _configured
+
+	if _configured:
+		return
+
+	root = logging.getLogger()
+	root.setLevel(_resolve_level(level))
+
+	formatter = logging.Formatter(LOG_FORMAT, datefmt=DATE_FORMAT)
+
+	# Card descriptions are scraped from the page and are not ASCII outside the
+	# en-US market, which the Windows console encoding cannot represent. Replace
+	# those characters instead of letting the write raise.
+	if hasattr(sys.stdout, "reconfigure"):
+		sys.stdout.reconfigure(errors="replace")
+
+	# stdout rather than the StreamHandler default of stderr, because this
+	# replaces print and anyone already redirecting stdout to a file should
+	# keep getting the same output there.
+	console = logging.StreamHandler(sys.stdout)
+	console.setFormatter(formatter)
+	root.addHandler(console)
+
+	if log_file is None:
+		log_file = os.environ.get(FILE_ENV_VAR)
+
+	if log_file:
+		# utf-8 explicitly. Card descriptions are scraped from the page and are
+		# not ASCII outside the en-US market, and the Windows default encoding
+		# would raise on them.
+		file_handler = logging.FileHandler(log_file, encoding="utf-8")
+		file_handler.setFormatter(formatter)
+		root.addHandler(file_handler)
+
+	_configured = True

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,11 @@
+import log_utils
 import rewards_tasks
 import mouse_trajectory
 import mimic_typing
 from selenium import webdriver
 from constants import USER_DATA_DIR, PROFILE_NAME
+
+log_utils.setup_logging()
 
 options = webdriver.EdgeOptions()
 

--- a/src/rewards_tasks.py
+++ b/src/rewards_tasks.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import random
 import time
@@ -16,6 +17,8 @@ import mimic_typing
 import element_selectors
 
 VISUAL_SEARCH_IMAGE_PATH = os.path.abspath("visual_search.jpg")
+
+logger = logging.getLogger(__name__)
 
 class RewardsTaskUtils:
 	def __init__(self, driver: webdriver.Edge):
@@ -113,7 +116,10 @@ class RewardsTaskUtils:
 
 		for card in explore_on_bing_links:
 			if not self.elements.card_is_complete(card):
-				print(f"[WARNING] Explore on Bing Card [desc={self.elements.extract_card_descriptions(card)!r}] is not complete after searching. Please check manually.")
+				logger.warning(
+					"Explore on Bing Card [desc=%r] is not complete after searching. Please check manually.",
+					self.elements.extract_card_descriptions(card)
+				)
 
 	def complete_visual_search(self):
 		self.switch_to_earn_page()
@@ -154,7 +160,10 @@ class RewardsTaskUtils:
 
 		for card in misc_cards:
 			if not self.elements.card_is_complete(card) and self.elements.get_card_point_value(card) > 0:
-				print(f"[WARNING] Misc Card [desc={self.elements.extract_card_descriptions(card)!r}] is not complete after clicking. Please check manually.")
+				logger.warning(
+					"Misc Card [desc=%r] is not complete after clicking. Please check manually.",
+					self.elements.extract_card_descriptions(card)
+				)
 
 		self.tab_utils.close_all_other_tabs()
 
@@ -170,7 +179,7 @@ class RewardsTaskUtils:
 		# Measure, search, measure again.
 		points_earned, max_pts = self.read_search_points()
 
-		print(f"[INFO] Search points before: {points_earned}/{max_pts}")
+		logger.info("Search points before: %s/%s", points_earned, max_pts)
 
 		for round_number in range(1, max_rounds + 1):
 			if points_earned >= max_pts:
@@ -184,16 +193,19 @@ class RewardsTaskUtils:
 			previous = points_earned
 			points_earned, max_pts = self.read_search_points()
 
-			print(f"[INFO] Round {round_number}: {searches} searches -> {points_earned}/{max_pts}")
+			logger.info(
+				"Round %s: %s searches -> %s/%s",
+				round_number, searches, points_earned, max_pts
+			)
 
 			if points_earned <= previous:
-				print("[WARNING] Round produced no points, stopping instead of searching pointlessly.")
+				logger.warning("Round produced no points, stopping instead of searching pointlessly.")
 				break
 
 		if points_earned < max_pts:
-			print(f"[WARNING] Search quota not filled: {points_earned}/{max_pts}")
+			logger.warning("Search quota not filled: %s/%s", points_earned, max_pts)
 		else:
-			print(f"Search quota complete: {points_earned}/{max_pts}")
+			logger.info("Search quota complete: %s/%s", points_earned, max_pts)
 
 	def read_search_points(self):
 		"""Open the points breakdown, read the Bing search row, close it again."""
@@ -230,7 +242,10 @@ class RewardsTaskUtils:
 
 			try: self.wait_for_then_click(self.elements.get_clear_bing_search_query_button)
 			except StaleElementReferenceException:
-				print(f"[WARNING] StaleElementReferenceException when trying to click the clear button for query {i+1}. Trying again...")
+				logger.warning(
+					"StaleElementReferenceException when trying to click the clear button for query %s. Trying again...",
+					i + 1
+				)
 				self.wait_for_then_click(self.elements.get_clear_bing_search_query_button)
 
 		self.driver.get("https://rewards.bing.com/")
@@ -244,7 +259,7 @@ class RewardsTaskUtils:
 		try:
 			self.wait_for_then_click(self.elements.get_claim_bonus_points_button)
 		except TimeoutException:
-			print("[WARNING] Could not find the 'Claim Bonus Points' button. There are likely no bonus points to claim at this time.")
+			logger.warning("Could not find the 'Claim Bonus Points' button. There are likely no bonus points to claim at this time.")
 
 	def complete_all_tasks(self):
 		# Each task is run independently. The Rewards UI differs by market and
@@ -260,13 +275,21 @@ class RewardsTaskUtils:
 		)
 
 		for name, step in steps:
+			# The tags stay in the message rather than being folded into the
+			# level, they are the per-task outcome summary and reading a run
+			# means scanning for them.
 			try:
 				step()
-				print(f"[OK] {name}")
+				logger.info("[OK] %s", name)
 			except (NoSuchElementException, TimeoutException) as exc:
-				print(f"[SKIP] {name}: not available in this UI variant ({type(exc).__name__})")
+				logger.warning("[SKIP] %s: not available in this UI variant (%s)", name, type(exc).__name__)
 			except Exception as exc:
-				print(f"[FAIL] {name}: {type(exc).__name__}: {exc}")
+				# Traceback only on debug, so a normal run keeps one line per task
+				# but a bug report can carry the full stack.
+				logger.error(
+					"[FAIL] %s: %s: %s", name, type(exc).__name__, exc,
+					exc_info=logger.isEnabledFor(logging.DEBUG)
+				)
 
 			# Leave a clean tab state behind for the next task.
 			try:

--- a/src/tab_utils.py
+++ b/src/tab_utils.py
@@ -1,5 +1,8 @@
+import logging
 from selenium.common.exceptions import WebDriverException, JavascriptException
 from selenium import webdriver
+
+logger = logging.getLogger(__name__)
 
 GHOST_TAB_URLS = (
 	"https://ntp.msn.com/edge/ntp?locale=en-US&title=New%20tab&fre=1&dsp=1&sp=Bing&feed_dis=always&en_widget_reg=false&prerender=1&PC=U531", # has fre
@@ -30,7 +33,7 @@ document.dispatchEvent(new Event('visibilitychange'));
 				self.driver.switch_to.window(handle)
 
 				if self.driver.current_url in GHOST_TAB_URLS:
-					print(f"[INFO] Found ghost tab with handle {handle} and URL {self.driver.current_url}.")
+					logger.info("Found ghost tab with handle %s and URL %s.", handle, self.driver.current_url)
 					continue
 
 				self.ensure_focus()
@@ -47,17 +50,17 @@ document.dispatchEvent(new Event('visibilitychange'));
 				self.driver.switch_to.window(handle)
 
 				if self.driver.current_url in GHOST_TAB_URLS:
-					print(f"[INFO] Found ghost tab with handle {handle} and URL {self.driver.current_url}, not closing.")
+					logger.info("Found ghost tab with handle %s and URL %s, not closing.", handle, self.driver.current_url)
 					continue
 
 				tab_url = self.driver.current_url
 
 				try:
 					self.driver.close()
-					print(f"[INFO] Closed tab with handle {handle} and URL {tab_url}.")
+					logger.info("Closed tab with handle %s and URL %s.", handle, tab_url)
 
 				except WebDriverException:
-					print(f"[WARNING] Could not close tab with handle {handle} and URL {tab_url}.")
+					logger.warning("Could not close tab with handle %s and URL %s.", handle, tab_url)
 					self.problematic_tabs.add(handle)
 					pass
 


### PR DESCRIPTION
Closes #14.

Now that #4 is merged this was unblocked, so I picked it up. Left a note on the issue before starting in case someone else was already on it.

## What changed

A new `src/log_utils.py` holds a `setup_logging()` that `main.py` calls once. Each runtime module keeps its own `logging.getLogger(__name__)`, so every line is attributable to the module it came from. Stdlib only, no new dependencies.

`[INFO]` and `[WARNING]` prefixes are dropped, the level field carries that now.

`[OK]`, `[SKIP]` and `[FAIL]` are **kept in the message text**. They are not severities, they are the per-task outcome summary from `complete_all_tasks`, and reading a run means scanning for them. They map to info / warning / error, which is the one thing `print` could not express: a genuine failure now sorts above a task that this UI variant simply does not ship.

```
10:26:24 INFO     rewards_tasks: [OK] Bing daily set
10:26:24 WARNING  rewards_tasks: [SKIP] Explore on Bing: not available in this UI variant (NoSuchElementException)
10:26:24 WARNING  rewards_tasks: [SKIP] Visual search: not available in this UI variant (TimeoutException)
10:26:24 ERROR    rewards_tasks: [FAIL] Misc cards: ValueError: kaboom
10:26:24 INFO     rewards_tasks: [OK] Required searches
10:26:24 INFO     rewards_tasks: [OK] Bonus points
```

## Two things that fall out of having levels at all

Both are off by default, so a normal run looks the same as before apart from the timestamp and level columns.

- **`REWARDS_FARMER_LOG_LEVEL=DEBUG`** attaches the traceback to every `[FAIL]`. This is the stack trace that bug reports keep having to be asked for, for example in #19, and it now comes for free with one environment variable rather than a code change.
- **`REWARDS_FARMER_LOG_FILE=run.log`** writes the same output to a file, so an unattended run can be read after the fact. The `llm_utils` timeout comment already treats the unattended scheduled run as a case worth designing for.

Both are documented in a short README section.

## Two smaller calls

**The console handler writes to stdout, not the `StreamHandler` default of stderr.** This replaces `print`, so anyone already redirecting stdout to a file should keep getting their output there.

**Its error handler is set to `replace`.** Card descriptions are scraped from the page and are not ASCII outside the en-US market, which is exactly what #4 opened up, and the Windows console encoding raises `UnicodeEncodeError` on them. I hit this while testing with a German card description containing a sun glyph: the `print` version and a naive `StreamHandler` both produce a `--- Logging error ---` instead of the line. The file handler is opened as utf-8 for the same reason. Happy to drop this if you would rather keep the PR to a pure swap, it is four lines in `log_utils.py`.

## Scope

Converted: `rewards_tasks.py`, `tab_utils.py`, `llm_utils.py`, plus `main.py` calling setup.

Deliberately **not** converted: `check_selectors.py`, `fitts_law.py`, `analyze_keypresses.py`. Their output is formatted report text, tables and section headers, and prefixing every row of a diagnostic table with a timestamp and a level makes it harder to read, not easier. Say the word if you would rather have it uniform across the repo and I will convert them too.

## Testing

I do not have a Microsoft account set up for this, so I could not do a full live run. What I did instead was stub the selenium layer and drive the real converted code paths, 27 checks covering:

- `complete_all_tasks` with fake steps that succeed, raise `NoSuchElementException`, raise `TimeoutException` and raise an unexpected `ValueError`, asserting each lands on the right level with the right tag and that all six tasks still report
- the traceback being absent at INFO and present at DEBUG, and being the right exception
- `setup_logging` being idempotent, defaulting to INFO, writing to stdout, opening the file handler as utf-8
- level resolution from a name, lowercase and whitespace, an int, the env var, and garbage falling back to INFO rather than raising, so a typo in an env var cannot take down an unattended run
- a non-ASCII card description reaching the log file intact and not producing a logging error on the console
- `tab_utils` ghost-tab notices logging at INFO under the right logger name

The stub harness is scaffolding rather than something I would drop into the repo, since there is no test setup here yet, but I am glad to contribute it as a starting point if you want one.
