### PR TITLE
lower the python floor to 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ You should also have an Ollama account created (for the LLM), the `ollama` tool 
 You must also provide an image for the script to upload to complete the visual search task. Currently, this image is named `keypress_times.png` and is located in the root directory of the project (yes, I used a random image from my keyboard analysis to do this). You may provide an image of your own, just ensure that the absolute path of the image is placed in the `VISUAL_SEARCH_IMAGE_PATH` constant at the top of `rewards_tasks.py`.
 
 Activate the virtual environment & install dependencies (you may have to use `python -m poetry` instead of `poetry`).
-You must have Python 3.14+ and Poetry installed.
+You must have Python 3.12+ and Poetry installed.
+
+If `iex (poetry env activate)` fails with *"Cannot bind argument to parameter 'Command' because it is null"*, `poetry install` did not create an environment. Run `python --version` first: an older Python leaves poetry with nothing to activate, and the message explaining that goes to stderr rather than into `iex`.
 
 Windows (PowerShell)
 ```sh

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,6 +26,7 @@ files = [
 
 [package.dependencies]
 idna = ">=2.8"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
 trio = ["trio (>=0.32.0)"]
@@ -5043,5 +5044,5 @@ h11 = ">=0.16.0,<1"
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.14"
-content-hash = "bea6193c41f407cdf51a6cb49dbc4c9ebd63b5e4bdf8ccc3be13cf218ff6f376"
+python-versions = ">=3.12"
+content-hash = "fd4eaf67a2a0849a8ce66dfd1ac2be20276da3d8a1454ef9d991214912a51d61"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Carl Furtado",email = "user0332@duck.com"}
 ]
 license = "MIT"
-requires-python = ">=3.14"
+requires-python = ">=3.12"
 dependencies = [
     "selenium (>=4.46.0,<5.0.0)",
     "matplotlib (>=3.11.1,<4.0.0)",


### PR DESCRIPTION
Fixes #26. Three files, seven lines.

## The bug

`requires-python = ">=3.14"`. On anything older, poetry declines to create an environment. It explains itself on **stderr** and leaves **stdout empty**. The README then says to run:

```powershell
iex (poetry env activate)
```

`iex` only receives stdout, so it gets nothing, and PowerShell reports:

```
Invoke-Expression : Cannot bind argument to parameter 'Command' because it is null.
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,...
```

The error names `iex`, so that is where people look. The first reply on #26 asked the reporter whether they had `iex` installed; it is a built-in PowerShell alias, so that road goes nowhere. The step that actually failed is the `poetry install` above it, and it failed quietly.

Reproduced on 3.12.10, character for character against the reporter's paste.

## Why 3.12 rather than 3.14

Three independent lines of evidence, all pointing at the same floor:

| check | result |
|---|---|
| Every file in `src/` compiled on **3.10** | passes |
| Grep for 3.13/3.14-only syntax across the tree | nothing found |
| Highest python floor in the dependency graph | `numpy`, `>=3.12` |
| Full task set run end to end on **3.12.10** against a live account | all six tasks completed |

`numpy` is what actually sets the boundary, and it lands on 3.12. That the empirical run and the dependency graph agree is the reason I am proposing 3.12 specifically rather than dropping the floor as far as it will go.

If the 3.14 pin was deliberate, for something planned rather than something present, say so and I will close this. I could not find a reason for it in the code, but absence of evidence in a tree I did not write is worth checking with you.

## Verified after the change, on 3.12.10

- `poetry install` creates the environment
- `poetry env activate` emits a real activation command instead of an empty string
- `iex (poetry env activate)` activates in PowerShell, which is the reported failure
- every dependency imports, and so does every module under `src/`

## On the lock file

Regenerated rather than left stale, because `requires-python` feeds its content hash and a stale hash breaks `poetry install` for everyone.

The diff is three lines. The package set is unchanged at 203, and the only substantive addition is a `typing_extensions` marker for `python_version < "3.13"`. I upgraded my poetry to **2.4.1** first, matching the version that wrote the existing file, so the generator comment does not flip and the diff stays limited to what the change actually requires.

## Note

Independent of #31 and touches no file it touches, so the two can merge in either order.
