### PR TITLE
wait for the breakdown panel's content, not just its container

### DIFF
--- a/src/check_selectors.py
+++ b/src/check_selectors.py
@@ -184,6 +184,18 @@ def main():
 		driver.execute_script("arguments[0].click();", elements.get_points_breakdown_button())
 		wait_until(lambda: elements.get_sidebar_section() is not None, 30)
 
+		# The section exists before it has content: the panel renders a
+		# "Loading..." placeholder inside it first, and that satisfies the
+		# presence check above immediately. Waiting only for the section leaves
+		# the two selectors below reading an empty panel, so they report FAILED
+		# for markup that is fine, on a page that is merely slow. Wait for the
+		# content itself. A selector that really is broken still reports FAILED,
+		# it just costs the timeout first.
+		wait_until(
+			lambda: elements.get_points_earned_from_searches_on_points_breakdown() is not None,
+			30,
+		)
+
 		report.check("get_sidebar_section", elements.get_sidebar_section)
 		report.check(
 			"get_points_earned_from_searches_on_points_breakdown",


### PR DESCRIPTION
`check_selectors.py` reports FAILED for two selectors that work.

## The bug

The wait before them is satisfied by a placeholder:

```python
wait_until(lambda: elements.get_sidebar_section() is not None, 30)
```

`get_sidebar_section` returns the first `<section>` whose id starts with `react-aria`. That section is in the DOM the moment the panel opens, holding a **"Loading..."** placeholder, so the presence check returns immediately. The two selectors below it then read the panel's text, get `"Loading..."`, and raise.

The report's own output gives it away: the section that resolves **OK** has the text `Loading...`, and the two entries beneath it fail.

## Before and after

On a healthy en-US account, latest `main`:

```
## points breakdown
  OK       get_sidebar_section                          'Loading...'
  FAILED   get_points_earned_from_searches_on_points_breakdown NoSuchElementException
  FAILED   get_close_button_on_points_breakdown         NoSuchElementException

OK=10  ABSENT=1  FAILED=2
```

With this change, same account, same run:

```
## points breakdown
  OK       get_sidebar_section                          "Points breakdown | Today's points | 480 | To"
  OK       get_points_earned_from_searches_on_points_breakdown (25, 25)
  OK       get_close_button_on_points_breakdown         ''

OK=12  ABSENT=1  FAILED=0
```

## Why it is worth fixing rather than living with

This is the tool the README points people at, and it says plainly that ABSENT is normal and **FAILED is what needs fixing**. A false FAILED therefore sends both the reporter and whoever triages the report after selectors that are fine, on a page whose only problem was being slow. It also makes the output useless as a signal: two permanent FAILEDs train people to ignore the line that is supposed to matter.

**The bot itself was never affected.** `read_search_points` reaches the same selector through `wait_for_element`, which waits properly. This is only the diagnostic.

## The fix

Wait for the content instead of the container. A selector that genuinely is broken still reports FAILED, it just costs the timeout first, which is the right trade for a tool whose entire job is telling those two cases apart.

Independent of #31 and touches no file it touches.
