### PR TITLE
name the visual search image the file the code actually looks for

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ cd rewards-farmer
 
 You should also have an Ollama account created (for the LLM), the `ollama` tool installed, and you should have signed in to the Ollama CLI via the command line using `ollama signin`. This project will use a minimal amount of Ollama cloud usage using `gemma4:cloud`. If you wish to use a different model, please change the `model` parameter in the `get_ollama_response` function in `src/llm_utils.py`.
 
-You must also provide an image for the script to upload to complete the visual search task. Currently, this image is named `keypress_times.png` and is located in the root directory of the project (yes, I used a random image from my keyboard analysis to do this). You may provide an image of your own, just ensure that the absolute path of the image is placed in the `VISUAL_SEARCH_IMAGE_PATH` constant at the top of `rewards_tasks.py`.
+You must also provide an image for the script to upload to complete the visual search task. No image ships with the repository, so put any image you like in the project root and name it **`visual_search.jpg`**. Any ordinary photo works; the task only requires that something is uploaded.
+
+If you would rather keep it elsewhere or under another name, change the `VISUAL_SEARCH_IMAGE_PATH` constant at the top of `src/rewards_tasks.py`.
+
+Without that file the visual search task fails with `InvalidArgumentException: File not found`.
 
 Activate the virtual environment & install dependencies (you may have to use `python -m poetry` instead of `poetry`).
 You must have Python 3.12+ and Poetry installed.


### PR DESCRIPTION
The README says the visual search image is `keypress_times.png`. The code reads a different name:

```python
VISUAL_SEARCH_IMAGE_PATH = os.path.abspath("visual_search.jpg")
```

Following the README as written therefore leaves the visual search task failing with

```
InvalidArgumentException: Message: invalid argument: File not found : ...\keypress_times.png
```

naming a file the README never mentions, which is a hard first-run failure to place.

Two related things the section implies but does not say, both checked:

- **No image is tracked in the repository.** `git ls-tree -r main` finds no `.png`, `.jpg` or `.jpeg` anywhere, so a fresh clone has neither file and every new user has to supply one. The current wording, "Currently, this image is named `keypress_times.png` and is located in the root directory of the project", reads as though the clone already contains it.
- **The constant already handles the path.** It wraps a bare filename in `os.path.abspath`, so a file sitting in the project root is enough and no code edit is needed for the common case. The instruction to put an absolute path into the constant is kept, but as the alternative it actually is.

Documentation only, no code change. Independent of #31 and #33.
