### PR TITLE
explain the startup failure when the profile is already open

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,10 @@
+import sys
+
 import rewards_tasks
 import mouse_trajectory
 import mimic_typing
 from selenium import webdriver
+from selenium.common.exceptions import SessionNotCreatedException
 from constants import USER_DATA_DIR, PROFILE_NAME
 
 options = webdriver.EdgeOptions()
@@ -12,7 +15,29 @@ options.add_argument("--disable-blink-features=AutomationControlled")
 options.add_argument(f"--user-data-dir={USER_DATA_DIR}")
 options.add_argument(f"--profile-directory={PROFILE_NAME}")
 
-driver = webdriver.Edge(options=options)
+try:
+	driver = webdriver.Edge(options=options)
+except SessionNotCreatedException as exc:
+	# Chromium allows one process per user data directory. When the profile is
+	# already open, the driver's copy exits on startup and selenium reports it
+	# as the browser crashing, with a message that mentions neither the profile
+	# nor another window. Observed wording varies between "Chrome instance
+	# exited" and "Microsoft Edge failed to start: crashed" for the same cause,
+	# so this keys on the exception rather than on the text.
+	print("Could not start Edge with the automation profile.")
+	print()
+	print(f"  profile directory: {USER_DATA_DIR}")
+	print(f"  profile name:      {PROFILE_NAME}")
+	print()
+	print("The usual cause is that this profile is already open in another Edge")
+	print("window, including one left over from a previous run. Close every window")
+	print("of that profile and run this again.")
+	print()
+	print("The driver's own message is repeated for reference. It names Chrome and")
+	print("points at a verbose log, neither of which applies here:")
+	print(f"  {str(exc).strip().splitlines()[0]}")
+
+	sys.exit(1)
 
 mouse = mouse_trajectory.MouseUtils(driver)
 keyboard = mimic_typing.KeyboardUtils(driver)


### PR DESCRIPTION
Part of #5 — the half @mardausdennis identified as not fixed by #4:

> The first traceback, SessionNotCreatedException with 'Chrome instance exited', is something else and not fixed by any PR: it usually means the automation profile is still open in another Edge window.

## The problem

Chromium allows one process per user data directory. With the profile already open, the driver's copy exits during startup and selenium raises:

```
selenium.common.exceptions.SessionNotCreatedException: Message: session not created:
Chrome instance exited. Examine ChromeDriver verbose log to determine the cause.
```

That message mentions neither the profile nor the other window. For a bot that drives Edge, being told to read a *ChromeDriver* log sends people somewhere that does not exist, and the traceback ends in selenium internals rather than anywhere in this project. It is a bad first-run experience and it has already cost one issue.

## What I checked

**Reproduced** by opening the profile in a normal Edge window and starting the driver against the same directory.

**The wording is not stable.** The same cause produced `Chrome instance exited` on one run and `Microsoft Edge failed to start: crashed` on another, so this keys on the exception type rather than matching text.

**The lockfile is not a usable signal**, which is worth recording since it is the obvious thing to reach for. `data-dir/lockfile` survives a forced kill and is cleared on a clean exit, and a driver start with no Edge running succeeds whether or not the file is present. So this reports the likely cause rather than claiming a detection it cannot actually make.

## After

```
Could not start Edge with the automation profile.

  profile directory: ...\rewards-farmer\data-dir
  profile name:      Default

The usual cause is that this profile is already open in another Edge
window, including one left over from a previous run. Close every window
of that profile and run this again.

The driver's own message is repeated for reference. It names Chrome and
points at a verbose log, neither of which applies here:
  Message: session not created: Chrome instance exited. ...
```

Exits 1. Verified both ways: exit code 1 with the profile held open, and driver construction unaffected when it is not.

## Ordering

This **conflicts with my own #31**, since both touch `src/main.py`. Whichever you take first, I will rebase the other the same day — please do not let that hold either up. It is independent of #33 and #34.
