### PR TITLE
logging, a query source without an LLM, multi-account and docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+data-dir/
+venv/
+.venv/
+__pycache__/
+**/__pycache__/
+*.pyc
+.git/
+.gitignore
+.vscode/
+*.log
+*.png
+*.jpg
+poetry.lock
+README.md
+docs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.png
 *.txt
+*.log
 !nouns.txt
 Todo.md
 data-dir/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# Runs the bot without installing Edge, a driver or Python on the host.
+#
+# The image carries only what main.py actually reaches: selenium and numpy.
+# pygetwindow, keyboard, matplotlib and pygame are used solely by the
+# recording and visualisation scripts, which are developer tools rather than
+# part of a run, and two of them are Windows-only.
+#
+# QUERY_SOURCE defaults to trends here so a container needs no Ollama account
+# and no model download. Set it to llm and point OLLAMA_HOST at a reachable
+# host to use a model instead.
+
+FROM python:3.12-slim-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Edge, from Microsoft's own repository.
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		ca-certificates curl gnupg unzip fonts-liberation \
+	&& curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
+		| gpg --dearmor -o /usr/share/keyrings/microsoft.gpg \
+	&& echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/edge stable main" \
+		> /etc/apt/sources.list.d/microsoft-edge.list \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends microsoft-edge-stable \
+	&& rm -rf /var/lib/apt/lists/*
+
+# The driver has to match the browser build, so it is pinned to whatever Edge
+# the layer above installed rather than to "latest", which drifts apart from it
+# between releases.
+RUN EDGE_VERSION="$(microsoft-edge --version | awk '{print $3}')" \
+	&& curl -fsSL -o /tmp/edgedriver.zip \
+		"https://msedgedriver.microsoft.com/${EDGE_VERSION}/edgedriver_linux64.zip" \
+	&& unzip -j /tmp/edgedriver.zip msedgedriver -d /usr/local/bin \
+	&& chmod +x /usr/local/bin/msedgedriver \
+	&& rm /tmp/edgedriver.zip \
+	&& msedgedriver --version
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir "selenium>=4.46.0,<5.0.0" "numpy"
+
+COPY src/ ./src/
+COPY nouns.txt ./
+
+# Headless because there is no display, and trends because there is no model.
+ENV REWARDS_HEADLESS=1 \
+	QUERY_SOURCE=trends \
+	PYTHONUNBUFFERED=1
+
+# Sign-in lives here, so it has to outlive the container.
+VOLUME ["/app/data-dir"]
+
+CMD ["python", "src/main.py"]

--- a/README.md
+++ b/README.md
@@ -48,4 +48,25 @@ EU Users: you may have to accept a consent banner once on `rewards.bing.com` and
 
 Close all webdriver browser instances. Run `main.py` again; the automation should start working.
 
+# Logging
+
+The script logs to the console. Two optional environment variables change that:
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `REWARDS_FARMER_LOG_LEVEL` | `INFO` | Set to `DEBUG` to also attach the full stack trace to every `[FAIL]` line. |
+| `REWARDS_FARMER_LOG_FILE` | unset | Path to also write the log to, useful for unattended runs. |
+
+Windows (PowerShell)
+```sh
+$env:REWARDS_FARMER_LOG_LEVEL="DEBUG"; $env:REWARDS_FARMER_LOG_FILE="run.log"; python src/main.py
+```
+
+*nix (Bash)
+```sh
+REWARDS_FARMER_LOG_LEVEL=DEBUG REWARDS_FARMER_LOG_FILE=run.log python src/main.py
+```
+
+If you are opening an issue about a crash, running with `REWARDS_FARMER_LOG_LEVEL=DEBUG` and attaching the log is the most useful thing you can include.
+
 Please open up a GitHub issue if you run into any difficulties.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Each is signed in once by hand, the same way as the single profile, using its ow
 msedge --user-data-dir="<repo>\data-dir\personal" --profile-directory=Default https://rewards.bing.com
 ```
 
-They run one after another, and a profile that fails to start is reported and skipped rather than ending the run. Leave `REWARDS_ACCOUNTS` unset and everything behaves exactly as before, using the single profile in `data-dir`.
+They run one after another, and an account that fails is reported and skipped rather than ending the run, whether it fails to start or dies partway through. Leave `REWARDS_ACCOUNTS` unset and everything behaves exactly as before, using the single profile in `data-dir`.
 
 # Docker
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ msedge --user-data-dir="<repo>\data-dir" --profile-directory=Default https://rew
 
 Close every window of that profile afterwards. Chromium allows one process per profile directory, so a window left open on the host stops the container from starting.
 
+**This does not work from a Windows host.** Chromium encrypts cookie values with a key held by the operating system, and on Windows that key is wrapped with DPAPI and tied to the Windows account that wrote it. The Linux container has no DPAPI, so it cannot unwrap the key and every cookie in the profile is unreadable to it. The volume carries the file in and the browser then ignores its contents: a profile signed in on the host reported 73 cookies on disk, of which Edge in the container could read 19 — the ones it had just set itself — while `.MSA.Auth` and `ANON`, the cookies the sign-in actually rests on, came back absent. The container starts, looks healthy and behaves as though it were logged out.
+
+Sign-in has to happen wherever the container will read it, so on a Windows host run the bot directly instead:
+
+```sh
+python src/main.py
+```
+
+Only the Windows case is measured here. A Linux host is expected to work, since the container falls back to the same scheme when no keyring is present, and macOS is expected to fail the same way for the same reason as Windows — it wraps the key with the login Keychain, which the container also cannot reach. Neither was tested.
+
 **Provide the visual search image on the host too.** `visual_search.jpg` is not in the repository and is not built into the image, so create it once in the project root and the compose file mounts it in:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ cd rewards-farmer
 # Edit the included nouns.txt file to add or replace words as needed
 ```
 
+# Where search queries come from
+
+The bot needs short strings to type into Bing. Two backends produce them, set with `QUERY_SOURCE`:
+
+| `QUERY_SOURCE` | Needs | Notes |
+| --- | --- | --- |
+| `llm` (default) | Ollama account + model | Current behaviour, unchanged |
+| `trends` | nothing | Google Trends, Wikipedia and Bing autosuggest |
+
+```sh
+QUERY_SOURCE=trends python src/main.py          # bash
+$env:QUERY_SOURCE="trends"; python src/main.py  # PowerShell
+```
+
+`trends` needs no account, no API key and no model download, so the Ollama setup below is optional if you use it. If every feed is unreachable it falls back to `nouns.txt` rather than failing the run.
+
 You should also have an Ollama account created (for the LLM), the `ollama` tool installed, and you should have signed in to the Ollama CLI via the command line using `ollama signin`. This project will use a minimal amount of Ollama cloud usage using `gemma4:cloud`. If you wish to use a different model, please change the `model` parameter in the `get_ollama_response` function in `src/llm_utils.py`.
 
 You must also provide an image for the script to upload to complete the visual search task. Currently, this image is named `keypress_times.png` and is located in the root directory of the project (yes, I used a random image from my keyboard analysis to do this). You may provide an image of your own, just ensure that the absolute path of the image is placed in the `VISUAL_SEARCH_IMAGE_PATH` constant at the top of `rewards_tasks.py`.

--- a/README.md
+++ b/README.md
@@ -66,4 +66,47 @@ EU Users: you may have to accept a consent banner once on `rewards.bing.com` and
 
 Close all webdriver browser instances. Run `main.py` again; the automation should start working.
 
+# Running more than one account
+
+Rewards is per Microsoft account and the browser profile holds the sign-in, so an account here is a profile directory. `REWARDS_ACCOUNTS` takes a comma separated list, and each name gets its own directory under `data-dir`:
+
+```sh
+REWARDS_ACCOUNTS=personal,spare python src/main.py
+```
+
+Each is signed in once by hand, the same way as the single profile, using its own directory:
+
+```
+msedge --user-data-dir="<repo>\data-dir\personal" --profile-directory=Default https://rewards.bing.com
+```
+
+They run one after another, and a profile that fails to start is reported and skipped rather than ending the run. Leave `REWARDS_ACCOUNTS` unset and everything behaves exactly as before, using the single profile in `data-dir`.
+
+# Docker
+
+Runs the bot without installing Edge, a driver or Python on the host.
+
+```sh
+docker compose build
+docker compose run --rm rewards-farmer
+```
+
+The container defaults to `QUERY_SOURCE=trends`, so it needs no Ollama account and no model. Set `QUERY_SOURCE=llm` and `OLLAMA_HOST` to a reachable address to use a model instead.
+
+**Sign in first.** The profile in `data-dir` starts logged out and the container has no display to sign in with, so do it once on the host with a normal Edge window and let the volume carry it in:
+
+```
+msedge --user-data-dir="<repo>\data-dir" --profile-directory=Default https://rewards.bing.com
+```
+
+Close every window of that profile afterwards. Chromium allows one process per profile directory, so a window left open on the host stops the container from starting.
+
+Multiple accounts work the same way in the container:
+
+```sh
+REWARDS_ACCOUNTS=personal,spare docker compose run --rm rewards-farmer
+```
+
+`REWARDS_HEADLESS=1` is set in the image. It also works on the host if you want a run with no visible window; the pointer code needs an explicit window size in that mode, which `main.py` sets.
+
 Please open up a GitHub issue if you run into any difficulties.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The container defaults to `QUERY_SOURCE=trends`, so it needs no Ollama account a
 msedge --user-data-dir="<repo>\data-dir" --profile-directory=Default https://rewards.bing.com
 ```
 
-Close every window of that profile afterwards. Chromium allows one process per profile directory, so a window left open on the host stops the container from starting.
+Close every window of that profile afterwards, and close them normally rather than killing the browser. Chromium allows one process per profile directory, so a window left open on the host stops the container from starting. A profile whose browser was killed is worse: it keeps a `SingletonLock` naming the machine that wrote it, the container reads that as the profile being open somewhere else, and it exits during startup with the same error a genuinely open window produces.
 
 **This does not work from a Windows host.** Chromium encrypts cookie values with a key held by the operating system, and on Windows that key is wrapped with DPAPI and tied to the Windows account that wrote it. The Linux container has no DPAPI, so it cannot unwrap the key and every cookie in the profile is unreadable to it. The volume carries the file in and the browser then ignores its contents: a profile signed in on the host reported 73 cookies on disk, of which Edge in the container could read 19 — the ones it had just set itself — while `.MSA.Auth` and `ANON`, the cookies the sign-in actually rests on, came back absent. The container starts, looks healthy and behaves as though it were logged out.
 
@@ -109,7 +109,9 @@ Sign-in has to happen wherever the container will read it, so on a Windows host 
 python src/main.py
 ```
 
-Only the Windows case is measured here. A Linux host is expected to work, since the container falls back to the same scheme when no keyring is present, and macOS is expected to fail the same way for the same reason as Windows — it wraps the key with the login Keychain, which the container also cannot reach. Neither was tested.
+**A Linux host does work.** With no keyring running Chromium falls back to a fixed key, which is the case both on a plain Linux host and inside the image, so the volume carries a working sign-in straight in. Measured: a profile signed in on the host opened in the container already on `rewards.bing.com/dashboard` and earned from it.
+
+macOS is expected to fail the way Windows does, since it wraps the key with the login Keychain and the container cannot reach that either, but that case was not tested.
 
 **Provide the visual search image on the host too.** `visual_search.jpg` is not in the repository and is not built into the image, so create it once in the project root and the compose file mounts it in:
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ msedge --user-data-dir="<repo>\data-dir" --profile-directory=Default https://rew
 
 Close every window of that profile afterwards. Chromium allows one process per profile directory, so a window left open on the host stops the container from starting.
 
+**Provide the visual search image on the host too.** `visual_search.jpg` is not in the repository and is not built into the image, so create it once in the project root and the compose file mounts it in:
+
+```sh
+python src/random_image_for_visual_search.py
+```
+
+Without it every other task still runs; only the visual search one fails.
+
 Multiple accounts work the same way in the container:
 
 ```sh
@@ -108,6 +116,7 @@ REWARDS_ACCOUNTS=personal,spare docker compose run --rm rewards-farmer
 ```
 
 `REWARDS_HEADLESS=1` is set in the image. It also works on the host if you want a run with no visible window; the pointer code needs an explicit window size in that mode, which `main.py` sets.
+
 # Logging
 
 The script logs to the console. Two optional environment variables change that:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+# docker compose run --rm rewards-farmer
+#
+# Sign-in has to happen once by hand before this is useful: the profile in
+# data-dir starts logged out. See the Docker section of the README.
+
+services:
+  rewards-farmer:
+    build: .
+    image: rewards-farmer
+    # Chromium wants more than the default 64MB of shared memory and crashes
+    # partway through a page without it.
+    shm_size: 1gb
+    environment:
+      # trends needs no account or model, which is why it is the default here.
+      # To use a model instead, set QUERY_SOURCE=llm and give OLLAMA_HOST an
+      # address the container can reach: localhost inside a container is the
+      # container, so ollama running on the host is host.docker.internal, and
+      # 0.0.0.0 is a bind address that cannot be dialled at all.
+      #
+      #   QUERY_SOURCE=llm OLLAMA_HOST=host.docker.internal:11434 docker compose run --rm rewards-farmer
+      QUERY_SOURCE: ${QUERY_SOURCE:-trends}
+      REWARDS_HEADLESS: "1"
+      # Comma separated, one profile directory each. Leave unset for a single
+      # profile in data-dir, which is the existing behaviour.
+      REWARDS_ACCOUNTS: ${REWARDS_ACCOUNTS:-}
+      OLLAMA_HOST: ${OLLAMA_HOST:-}
+    volumes:
+      # Keeps the sign-in across container rebuilds.
+      - ./data-dir:/app/data-dir

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,3 +27,8 @@ services:
     volumes:
       # Keeps the sign-in across container rebuilds.
       - ./data-dir:/app/data-dir
+      # The visual search task uploads this file, which is gitignored and so is
+      # never in the image. Create it first with
+      # `python src/random_image_for_visual_search.py`; a path that does not
+      # exist yet is mounted as an empty directory rather than a file.
+      - ./visual_search.jpg:/app/visual_search.jpg:ro

--- a/src/accounts.py
+++ b/src/accounts.py
@@ -1,0 +1,85 @@
+"""Which accounts a run works through.
+
+Rewards is per Microsoft account, and the browser profile is what holds the
+sign-in, so an account here is just a profile directory. One directory per
+account keeps their cookies apart, which is the whole requirement.
+
+    REWARDS_ACCOUNTS=personal,spare python src/main.py
+
+Unset, the run uses the single profile in constants.py exactly as before, so
+nothing about an existing setup changes.
+"""
+
+import os
+import re
+from dataclasses import dataclass
+
+from constants import USER_DATA_DIR, PROFILE_NAME
+
+ENV_VAR = "REWARDS_ACCOUNTS"
+
+# Names become directory names, so keep them to something a filesystem and a
+# command line both handle without quoting.
+SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+@dataclass(frozen=True)
+class Account:
+	"""A named browser profile to run the tasks against."""
+
+	name: str
+	user_data_dir: str
+	profile_name: str
+
+	@property
+	def is_default(self) -> bool:
+		return self.user_data_dir == USER_DATA_DIR
+
+
+def _named(name: str) -> Account:
+	# Each account gets its own directory under the configured one, so the
+	# existing data-dir stays where it is and the new ones sit beside the
+	# profile it already holds.
+	return Account(
+		name=name,
+		user_data_dir=os.path.join(USER_DATA_DIR, name),
+		profile_name=PROFILE_NAME,
+	)
+
+
+def configured() -> list[Account]:
+	"""Accounts for this run, in order.
+
+	Raises ValueError on a name that cannot be a directory, rather than
+	silently creating something surprising next to the real profiles.
+	"""
+	raw = os.environ.get(ENV_VAR, "").strip()
+
+	if not raw:
+		return [Account(name="default", user_data_dir=USER_DATA_DIR, profile_name=PROFILE_NAME)]
+
+	names = [part.strip() for part in raw.split(",")]
+	names = [name for name in names if name]
+
+	if not names:
+		return [Account(name="default", user_data_dir=USER_DATA_DIR, profile_name=PROFILE_NAME)]
+
+	seen: set[str] = set()
+	accounts: list[Account] = []
+
+	for name in names:
+		if not SAFE_NAME.match(name):
+			raise ValueError(
+				f"{ENV_VAR} entry {name!r} is not usable as a directory name; "
+				"use letters, digits, dot, dash or underscore"
+			)
+
+		# Duplicates would run the same profile twice, which earns nothing the
+		# second time and doubles the run length.
+		if name.lower() in seen:
+			continue
+
+		seen.add(name.lower())
+		accounts.append(_named(name))
+
+	return accounts

--- a/src/accounts.py
+++ b/src/accounts.py
@@ -19,8 +19,14 @@ from constants import USER_DATA_DIR, PROFILE_NAME
 ENV_VAR = "REWARDS_ACCOUNTS"
 
 # Names become directory names, so keep them to something a filesystem and a
-# command line both handle without quoting.
+# command line both handle without quoting. The character set alone is not
+# enough: "." and ".." are made of allowed characters and still walk out of the
+# directory, so they are rejected by name below and the resolved path is
+# checked as well.
 SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Reserved by every filesystem that has directories at all.
+RESERVED_NAMES = {".", ".."}
 
 
 @dataclass(frozen=True)
@@ -40,9 +46,22 @@ def _named(name: str) -> Account:
 	# Each account gets its own directory under the configured one, so the
 	# existing data-dir stays where it is and the new ones sit beside the
 	# profile it already holds.
+	user_data_dir = os.path.join(USER_DATA_DIR, name)
+
+	# The name passed the character check, but that only constrains the
+	# characters, not where they end up pointing. Confirm against the resolved
+	# path, which is the thing Edge is actually handed.
+	root = os.path.abspath(USER_DATA_DIR)
+	resolved = os.path.abspath(user_data_dir)
+
+	if os.path.commonpath([root, resolved]) != root or resolved == root:
+		raise ValueError(
+			f"{ENV_VAR} entry {name!r} resolves outside the profile directory"
+		)
+
 	return Account(
 		name=name,
-		user_data_dir=os.path.join(USER_DATA_DIR, name),
+		user_data_dir=user_data_dir,
 		profile_name=PROFILE_NAME,
 	)
 
@@ -68,7 +87,7 @@ def configured() -> list[Account]:
 	accounts: list[Account] = []
 
 	for name in names:
-		if not SAFE_NAME.match(name):
+		if not SAFE_NAME.match(name) or name in RESERVED_NAMES:
 			raise ValueError(
 				f"{ENV_VAR} entry {name!r} is not usable as a directory name; "
 				"use letters, digits, dot, dash or underscore"

--- a/src/accounts.py
+++ b/src/accounts.py
@@ -50,9 +50,11 @@ def _named(name: str) -> Account:
 
 	# The name passed the character check, but that only constrains the
 	# characters, not where they end up pointing. Confirm against the resolved
-	# path, which is the thing Edge is actually handed.
-	root = os.path.abspath(USER_DATA_DIR)
-	resolved = os.path.abspath(user_data_dir)
+	# path, which is the thing Edge is actually handed. realpath rather than
+	# abspath, so a link or a junction under the profile directory is followed
+	# to where it really goes instead of being taken at face value.
+	root = os.path.realpath(USER_DATA_DIR)
+	resolved = os.path.realpath(user_data_dir)
 
 	if os.path.commonpath([root, resolved]) != root or resolved == root:
 		raise ValueError(
@@ -87,10 +89,15 @@ def configured() -> list[Account]:
 	accounts: list[Account] = []
 
 	for name in names:
-		if not SAFE_NAME.match(name) or name in RESERVED_NAMES:
+		# The trailing dot is not cosmetic. Win32 strips one off a path
+		# component and python's normalisation does not, so such a name means a
+		# different directory than it reads as: "work." is "work", and "..." is
+		# the profile directory itself. Either way two entries end up sharing
+		# one profile, which is the one thing this module exists to prevent.
+		if not SAFE_NAME.match(name) or name in RESERVED_NAMES or name.endswith("."):
 			raise ValueError(
 				f"{ENV_VAR} entry {name!r} is not usable as a directory name; "
-				"use letters, digits, dot, dash or underscore"
+				"use letters, digits, dot, dash or underscore, and do not end in a dot"
 			)
 
 		# Duplicates would run the same profile twice, which earns nothing the

--- a/src/llm_utils.py
+++ b/src/llm_utils.py
@@ -1,6 +1,9 @@
 from typing import Generator
+import logging
 import random
 import ollama
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_SYSTEM_PROMPT_FOR_SEARCH_QUEST = (
 	"You are a helpful assistant tasked with creating a search query based on a directive. "
@@ -55,7 +58,7 @@ def get_nonempty_ollama_response(messages: list[dict[str, str]]) -> str:
 		if response and response.strip():
 			return response
 
-		print(f"[WARNING] Empty LLM response, retry {attempt + 1}/{MAX_EMPTY_RETRIES}")
+		logger.warning("Empty LLM response, retry %s/%s", attempt + 1, MAX_EMPTY_RETRIES)
 
 	raise RuntimeError(f"LLM returned nothing usable after {MAX_EMPTY_RETRIES} attempts")
 

--- a/src/log_utils.py
+++ b/src/log_utils.py
@@ -1,0 +1,100 @@
+"""Central logging configuration.
+
+`setup_logging` is called once from `main.py`. Every other module just does
+`logger = logging.getLogger(__name__)` at import time, which is safe to do
+before this runs, so import order does not matter.
+"""
+
+import logging
+import os
+import sys
+
+LEVEL_ENV_VAR = "REWARDS_FARMER_LOG_LEVEL"
+FILE_ENV_VAR = "REWARDS_FARMER_LOG_FILE"
+
+DEFAULT_LEVEL = "INFO"
+
+# Configuring the root logger switches on output for every library that logs,
+# not just ours. httpx emits an info line per ollama call, which buries the
+# task summary and puts the ollama endpoint in the log file. print never did
+# this because it never touched logging at all, so leaving these at their
+# default would make the output noisier than what it replaces.
+NOISY_LIBRARIES = ("httpx", "httpcore", "urllib3", "selenium")
+
+# CRITICAL is the longest level name at 8 characters, so pad to that and the
+# message column stays aligned no matter what is being logged.
+LOG_FORMAT = "%(asctime)s %(levelname)-8s %(name)s: %(message)s"
+DATE_FORMAT = "%H:%M:%S"
+
+_configured = False
+
+
+def _resolve_level(level: str | int | None) -> int:
+	"""Turn a level name, a level number or None into a level number.
+
+	An unusable value falls back to the default rather than raising. A typo in
+	an environment variable must not be able to take down an unattended run.
+	"""
+	if level is None:
+		level = os.environ.get(LEVEL_ENV_VAR, DEFAULT_LEVEL)
+
+	if isinstance(level, int):
+		return level
+
+	resolved = logging.getLevelNamesMapping().get(str(level).strip().upper())
+
+	if resolved is None:
+		logging.getLogger(__name__).warning(
+			"Unknown log level %r, falling back to %s", level, DEFAULT_LEVEL
+		)
+
+		return logging.getLevelNamesMapping()[DEFAULT_LEVEL]
+
+	return resolved
+
+
+def setup_logging(level: str | int | None = None, log_file: str | None = None) -> None:
+	"""Configure the root logger. Calling this more than once is a no-op.
+
+	`level` defaults to $REWARDS_FARMER_LOG_LEVEL, then to INFO.
+	`log_file` defaults to $REWARDS_FARMER_LOG_FILE, and no file is written
+	when neither is set.
+	"""
+	global _configured
+
+	if _configured:
+		return
+
+	root = logging.getLogger()
+	root.setLevel(_resolve_level(level))
+
+	formatter = logging.Formatter(LOG_FORMAT, datefmt=DATE_FORMAT)
+
+	# Card descriptions are scraped from the page and are not ASCII outside the
+	# en-US market, which the Windows console encoding cannot represent. Replace
+	# those characters instead of letting the write raise.
+	if hasattr(sys.stdout, "reconfigure"):
+		sys.stdout.reconfigure(errors="replace")
+
+	# stdout rather than the StreamHandler default of stderr, because this
+	# replaces print and anyone already redirecting stdout to a file should
+	# keep getting the same output there.
+	console = logging.StreamHandler(sys.stdout)
+	console.setFormatter(formatter)
+	root.addHandler(console)
+
+	if log_file is None:
+		log_file = os.environ.get(FILE_ENV_VAR)
+
+	if log_file:
+		# utf-8 explicitly. Card descriptions are scraped from the page and are
+		# not ASCII outside the en-US market, and the Windows default encoding
+		# would raise on them.
+		file_handler = logging.FileHandler(log_file, encoding="utf-8")
+		file_handler.setFormatter(formatter)
+		root.addHandler(file_handler)
+
+	for name in NOISY_LIBRARIES:
+		logging.getLogger(name).setLevel(logging.WARNING)
+
+	_configured = True

--- a/src/log_utils.py
+++ b/src/log_utils.py
@@ -7,6 +7,7 @@ before this runs, so import order does not matter.
 
 import logging
 import os
+import re
 import sys
 
 LEVEL_ENV_VAR = "REWARDS_FARMER_LOG_LEVEL"
@@ -20,6 +21,36 @@ DEFAULT_LEVEL = "INFO"
 # this because it never touched logging at all, so leaving these at their
 # default would make the output noisier than what it replaces.
 NOISY_LIBRARIES = ("httpx", "httpcore", "urllib3", "selenium")
+
+# Longest a one-line exception summary may get before it is cut. Long enough
+# for any real selenium message, short enough that a pathological one cannot
+# push a whole screen of text into a single record.
+MAX_SUMMARY_LENGTH = 300
+
+_SESSION_INFO = re.compile(r"\s*\(Session info:[^)]*\)")
+
+
+def exception_summary(exc: BaseException) -> str:
+	"""One short line describing an exception, safe to put in a log record.
+
+	str() on a selenium exception is multi-line: the message, then a session
+	info line, then the whole msedgedriver stacktrace. Only the first line is
+	worth showing in a per-task summary, and the full detail is still attached
+	as a traceback when the level is debug.
+	"""
+	text = str(exc).strip()
+
+	if not text:
+		return ""
+
+	text = _SESSION_INFO.sub("", text.splitlines()[0]).strip()
+
+	if len(text) > MAX_SUMMARY_LENGTH:
+		# ASCII, because this can land on a Windows console whose encoding
+		# cannot represent an ellipsis character.
+		text = text[:MAX_SUMMARY_LENGTH - 3].rstrip() + "..."
+
+	return text
 
 # CRITICAL is the longest level name at 8 characters, so pad to that and the
 # message column stays aligned no matter what is being logged.

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,11 @@
+import log_utils
 import rewards_tasks
 import mouse_trajectory
 import mimic_typing
 from selenium import webdriver
 from constants import USER_DATA_DIR, PROFILE_NAME
+
+log_utils.setup_logging()
 
 options = webdriver.EdgeOptions()
 

--- a/src/main.py
+++ b/src/main.py
@@ -5,8 +5,6 @@ import sys
 import log_utils
 import accounts
 import rewards_tasks
-import mouse_trajectory
-import mimic_typing
 from selenium import webdriver
 from selenium.common.exceptions import SessionNotCreatedException
 
@@ -54,9 +52,6 @@ def run_account(account: accounts.Account) -> bool:
 		return False
 
 	try:
-		mouse = mouse_trajectory.MouseUtils(driver)
-		keyboard = mimic_typing.KeyboardUtils(driver)
-
 		rewards = rewards_tasks.RewardsTaskUtils(driver)
 		rewards.complete_all_tasks()
 	finally:

--- a/src/main.py
+++ b/src/main.py
@@ -55,7 +55,16 @@ def run_account(account: accounts.Account) -> bool:
 		rewards = rewards_tasks.RewardsTaskUtils(driver)
 		rewards.complete_all_tasks()
 	finally:
-		driver.quit()
+		try:
+			driver.quit()
+		except Exception as exc:
+			# quit() raises when the browser is already gone. Letting it out
+			# here would replace whatever actually went wrong with the tidy-up's
+			# own error, and the process it is meant to end is dead anyway.
+			logger.warning(
+				"%s: the driver did not shut down cleanly: %s",
+				account.name, log_utils.exception_summary(exc)
+			)
 
 	return True
 
@@ -76,8 +85,21 @@ def main() -> int:
 		if len(configured) > 1:
 			logger.info("=== account: %s ===", account.name)
 
-		if run_account(account):
-			started += 1
+		# One account must not be able to end the batch. complete_all_tasks
+		# already contains a task that fails, and run_account names the profile
+		# that is already open, but everything else - a driver that will not
+		# start for some other reason, the browser dying mid-run, a page that
+		# never loads - reached here and took the remaining accounts with it.
+		# KeyboardInterrupt is deliberately not caught: Ctrl-C means stop.
+		try:
+			if run_account(account):
+				started += 1
+		except Exception as exc:
+			logger.error(
+				"[FAIL] %s: %s: %s",
+				account.name, type(exc).__name__, log_utils.exception_summary(exc),
+				exc_info=logger.isEnabledFor(logging.DEBUG)
+			)
 
 	if len(configured) > 1:
 		logger.info("%s/%s accounts ran", started, len(configured))

--- a/src/main.py
+++ b/src/main.py
@@ -1,26 +1,92 @@
+import os
+import sys
+
+import accounts
 import rewards_tasks
 import mouse_trajectory
 import mimic_typing
 from selenium import webdriver
-from constants import USER_DATA_DIR, PROFILE_NAME
+from selenium.common.exceptions import SessionNotCreatedException
 
-options = webdriver.EdgeOptions()
+HEADLESS = os.environ.get("REWARDS_HEADLESS", "").strip().lower() in ("1", "true", "yes")
 
-options.add_experimental_option("excludeSwitches", ["enable-automation"])
-options.add_experimental_option('useAutomationExtension', False)
-options.add_argument("--disable-blink-features=AutomationControlled")
-options.add_argument(f"--user-data-dir={USER_DATA_DIR}")
-options.add_argument(f"--profile-directory={PROFILE_NAME}")
 
-driver = webdriver.Edge(options=options)
+def build_options(account: accounts.Account) -> webdriver.EdgeOptions:
+	options = webdriver.EdgeOptions()
 
-mouse = mouse_trajectory.MouseUtils(driver)
-keyboard = mimic_typing.KeyboardUtils(driver)
+	options.add_experimental_option("excludeSwitches", ["enable-automation"])
+	options.add_experimental_option('useAutomationExtension', False)
+	options.add_argument("--disable-blink-features=AutomationControlled")
+	options.add_argument(f"--user-data-dir={account.user_data_dir}")
+	options.add_argument(f"--profile-directory={account.profile_name}")
 
-rewards = rewards_tasks.RewardsTaskUtils(driver)
+	if HEADLESS:
+		# A container has no display. The window size is set explicitly because
+		# the pointer code works in viewport coordinates, and the default
+		# headless window is small enough to put cards out of reach.
+		options.add_argument("--headless=new")
+		options.add_argument("--window-size=1920,1080")
+		options.add_argument("--no-sandbox")
+		options.add_argument("--disable-dev-shm-usage")
 
-rewards.complete_all_tasks()
+	return options
 
-input("Press Enter to exit...")
 
-driver.quit()
+def run_account(account: accounts.Account) -> bool:
+	"""Work one account. Returns whether the browser started."""
+	try:
+		driver = webdriver.Edge(options=build_options(account))
+	except SessionNotCreatedException as exc:
+		# Chromium allows one process per user data directory. When the profile
+		# is already open the driver's copy exits during startup, and selenium
+		# reports it as the browser crashing with a message that names neither
+		# the profile nor the other window.
+		print(f"[FAIL] {account.name}: could not start Edge with this profile.")
+		print(f"       profile directory: {account.user_data_dir}")
+		print("       The usual cause is that this profile is already open in another")
+		print("       Edge window, including one left over from a previous run.")
+		print(f"       driver said: {str(exc).strip().splitlines()[0]}")
+
+		return False
+
+	try:
+		mouse = mouse_trajectory.MouseUtils(driver)
+		keyboard = mimic_typing.KeyboardUtils(driver)
+
+		rewards = rewards_tasks.RewardsTaskUtils(driver)
+		rewards.complete_all_tasks()
+	finally:
+		driver.quit()
+
+	return True
+
+
+def main() -> int:
+	try:
+		configured = accounts.configured()
+	except ValueError as exc:
+		print(f"[FAIL] {exc}")
+
+		return 2
+
+	started = 0
+
+	for account in configured:
+		if len(configured) > 1:
+			print(f"\n=== account: {account.name} ===")
+
+		if run_account(account):
+			started += 1
+
+	if len(configured) > 1:
+		print(f"\n{started}/{len(configured)} accounts ran")
+
+	# Nothing is watching a container, and stdin is not a terminal there.
+	if not HEADLESS:
+		input("Press Enter to exit...")
+
+	return 0 if started else 1
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/src/queries.py
+++ b/src/queries.py
@@ -49,7 +49,7 @@ def search_query_for_task(task_description: str) -> str:
 
 		# Every feed was unreachable. The description still contains the topic,
 		# so a trimmed version beats skipping the card entirely.
-		logger.warning("No query source reachable, using the task description as written.")
+		logger.warning("No query source reachable, using the lowercased task description.")
 
 		return task_description.lower()
 

--- a/src/queries.py
+++ b/src/queries.py
@@ -13,8 +13,13 @@ Bing, and Bing's own autosuggest answers that question directly.
 
 import os
 
-import llm_utils
 import query_sources
+
+# llm_utils is imported inside the llm branch rather than here. It imports
+# ollama at module scope, so importing it eagerly would make the ollama package
+# a hard requirement even for a run that never touches a model, which is the
+# opposite of the point. A trends-only install, the Docker image for instance,
+# does not ship it.
 
 LLM = "llm"
 TRENDS = "trends"
@@ -45,6 +50,8 @@ def search_query_for_task(task_description: str) -> str:
 
 		return task_description.lower()
 
+	import llm_utils
+
 	return llm_utils.get_search_query_from_task_description(task_description)
 
 
@@ -59,6 +66,8 @@ def related_queries(count: int):
 		print("[WARNING] No query source reachable, falling back to the wordlist.")
 
 		# nouns.txt is already in the repo for exactly this kind of seed.
-		return [llm_utils.get_random_noun() for _ in range(count)]
+		return query_sources.wordlist_queries(count)
+
+	import llm_utils
 
 	return llm_utils.get_related_search_queries(llm_utils.get_random_noun(), num_queries=count)

--- a/src/queries.py
+++ b/src/queries.py
@@ -1,0 +1,64 @@
+"""Where search queries come from.
+
+Two backends. `llm` is the default and is unchanged, so nothing about an
+existing setup moves. `trends` uses public feeds and needs no account, no
+model and no key, which is the difference between running this in five
+minutes and installing Ollama first.
+
+    QUERY_SOURCE=trends python src/main.py
+
+The LLM's whole job in this project is producing short strings to type into
+Bing, and Bing's own autosuggest answers that question directly.
+"""
+
+import os
+
+import llm_utils
+import query_sources
+
+LLM = "llm"
+TRENDS = "trends"
+
+DEFAULT_SOURCE = LLM
+
+ENV_VAR = "QUERY_SOURCE"
+
+
+def selected_source() -> str:
+	"""Read on each call so a test can change it without reimporting."""
+	choice = os.environ.get(ENV_VAR, DEFAULT_SOURCE).strip().lower()
+
+	return choice if choice in (LLM, TRENDS) else DEFAULT_SOURCE
+
+
+def search_query_for_task(task_description: str) -> str:
+	"""A query for one "Search on Bing for X" card."""
+	if selected_source() == TRENDS:
+		query = query_sources.query_from_task_description(task_description)
+
+		if query:
+			return query
+
+		# Every feed was unreachable. The description still contains the topic,
+		# so a trimmed version beats skipping the card entirely.
+		print("[WARNING] No query source reachable, using the task description as written.")
+
+		return task_description.lower()
+
+	return llm_utils.get_search_query_from_task_description(task_description)
+
+
+def related_queries(count: int):
+	"""`count` queries for the daily search quota."""
+	if selected_source() == TRENDS:
+		queries = query_sources.related_queries(count)
+
+		if queries:
+			return queries
+
+		print("[WARNING] No query source reachable, falling back to the wordlist.")
+
+		# nouns.txt is already in the repo for exactly this kind of seed.
+		return [llm_utils.get_random_noun() for _ in range(count)]
+
+	return llm_utils.get_related_search_queries(llm_utils.get_random_noun(), num_queries=count)

--- a/src/query_sources.py
+++ b/src/query_sources.py
@@ -130,6 +130,24 @@ def suggestions(seed: str) -> list[str]:
 	return [_clean(s) for s in payload[1] if _clean(s)]
 
 
+def wordlist_queries(count: int) -> list[str]:
+	"""Seeds from nouns.txt, the last resort when nothing is reachable.
+
+	Read here rather than borrowed from llm_utils so that a trends-only install
+	never has to import the model client.
+	"""
+	try:
+		with open("nouns.txt", encoding="utf-8") as handle:
+			nouns = [line.strip().lower() for line in handle if len(line.strip()) >= 3]
+	except OSError:
+		return []
+
+	if not nouns:
+		return []
+
+	return random.sample(nouns, min(count, len(nouns)))
+
+
 def _clean(text: str) -> str:
 	"""Strip markup, collapse whitespace and drop punctuation Bing does not need."""
 	text = re.sub(r"<[^>]+>", " ", text or "")

--- a/src/query_sources.py
+++ b/src/query_sources.py
@@ -1,0 +1,198 @@
+"""Search queries from public feeds instead of a language model.
+
+The LLM in this project has one job: produce short strings to type into Bing.
+That is worth an Ollama account and a model download if you want it, but it is
+not the only way to get a search query, and it is the piece that stops someone
+running the bot in five minutes.
+
+Three keyless sources, all stdlib, no new dependencies:
+
+  Google Trends RSS   real queries people are typing right now
+  Wikipedia most-read topic seeds, useful when trends is unavailable
+  Bing autosuggest    expands a seed into related queries
+
+Autosuggest is what makes the chaining work. Asking Bing what follows a term
+gives queries Bing itself expects, which is closer to what the LLM prompt was
+reaching for than a model guessing in the dark.
+
+Every source degrades rather than raises. A search that does not happen costs
+points; a run that dies costs the rest of the day's points too.
+"""
+
+import json
+import random
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import date, timedelta
+
+TRENDS_URL = "https://trends.google.com/trending/rss?geo={geo}"
+WIKIPEDIA_URL = "https://en.wikipedia.org/api/rest_v1/feed/featured/{y}/{m:02d}/{d:02d}"
+AUTOSUGGEST_URL = "https://api.bing.com/osjson.aspx?query={query}"
+
+# A browser agent: trends and the Wikipedia REST feed both answer differently
+# to an unfamiliar client, and one of them refuses outright.
+USER_AGENT = (
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+	"(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+
+REQUEST_TIMEOUT = 15
+
+# Words that make a query read as an instruction rather than a search. The
+# task descriptions are phrased at the user, "Search on Bing to compare
+# checking accounts", and typing that verbatim searches for the sentence.
+INSTRUCTION_WORDS = {
+	"search", "searching", "bing", "on", "to", "the", "a", "an", "for", "your",
+	"you", "use", "using", "find", "get", "with", "and", "or", "of", "in",
+	"at", "by", "now", "today", "this", "that", "these", "those", "learn",
+	"discover", "explore", "check", "see", "our", "more", "about", "how",
+}
+
+
+def _fetch(url: str) -> str | None:
+	"""Body of a GET, or None. Never raises: callers fall through to the next source."""
+	request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+
+	try:
+		with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:
+			return response.read().decode("utf-8", "replace")
+	except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError):
+		return None
+
+
+def trending_queries(geo: str = "US") -> list[str]:
+	"""Queries currently trending on Google, most popular first.
+
+	These are real searches rather than descriptions of searches, which is
+	exactly the shape wanted here.
+	"""
+	body = _fetch(TRENDS_URL.format(geo=urllib.parse.quote(geo)))
+
+	if not body:
+		return []
+
+	# The channel carries a <title> of its own before any item, so the first
+	# match is the feed name rather than a query.
+	titles = re.findall(r"<title>(?:<!\[CDATA\[)?(.*?)(?:\]\]>)?</title>", body, re.S)
+
+	return [_clean(t) for t in titles[1:] if _clean(t)]
+
+
+def wikipedia_topics(days_ago: int = 1) -> list[str]:
+	"""Most-read Wikipedia articles, as topic seeds.
+
+	Yesterday by default: today's feed is not published until the day is over.
+	"""
+	day = date.today() - timedelta(days=days_ago)
+	body = _fetch(WIKIPEDIA_URL.format(y=day.year, m=day.month, d=day.day))
+
+	if not body:
+		return []
+
+	try:
+		payload = json.loads(body)
+	except json.JSONDecodeError:
+		return []
+
+	articles = payload.get("mostread", {}).get("articles", [])
+	titles = [a.get("titles", {}).get("normalized", "") for a in articles]
+
+	# Wikipedia's own chrome outranks real topics most days.
+	skipped = ("Main Page", "Special:", "Wikipedia:", "Portal:")
+
+	return [
+		_clean(t) for t in titles
+		if t and not t.startswith(skipped) and _clean(t)
+	]
+
+
+def suggestions(seed: str) -> list[str]:
+	"""What Bing suggests for a term, which is what Bing expects to be asked."""
+	if not seed.strip():
+		return []
+
+	body = _fetch(AUTOSUGGEST_URL.format(query=urllib.parse.quote(seed)))
+
+	if not body:
+		return []
+
+	try:
+		payload = json.loads(body)
+	except json.JSONDecodeError:
+		return []
+
+	# Opensearch shape: [term, [suggestions], ...]
+	if not isinstance(payload, list) or len(payload) < 2 or not isinstance(payload[1], list):
+		return []
+
+	return [_clean(s) for s in payload[1] if _clean(s)]
+
+
+def _clean(text: str) -> str:
+	"""Strip markup, collapse whitespace and drop punctuation Bing does not need."""
+	text = re.sub(r"<[^>]+>", " ", text or "")
+	text = re.sub(r"[\"'?!,;:]", " ", text)
+
+	return " ".join(text.split()).strip().lower()
+
+
+def query_from_task_description(description: str) -> str | None:
+	"""A search query for a task phrased as an instruction.
+
+	"Search on Bing to compare checking and savings account options" becomes
+	the content words, then whatever Bing suggests for them, so the query is
+	one Bing already recognises rather than the sentence itself.
+	"""
+	words = [w for w in _clean(description).split() if w not in INSTRUCTION_WORDS]
+
+	if not words:
+		return None
+
+	seed = " ".join(words[:6])
+	options = suggestions(seed)
+
+	# Prefer a suggestion, since it is a query Bing has seen. The trimmed
+	# sentence is a reasonable fallback and still beats typing the imperative.
+	return options[0] if options else seed
+
+
+def related_queries(count: int, seed: str | None = None) -> list[str]:
+	"""`count` distinct queries, branching out the way the LLM prompt asks for.
+
+	Trending queries first, since they need no expansion at all, then Bing's
+	suggestions for each to reach the requested number.
+	"""
+	collected: list[str] = []
+	seen: set[str] = set()
+
+	def take(candidates):
+		for candidate in candidates:
+			if candidate and candidate not in seen and len(candidate) > 2:
+				seen.add(candidate)
+				collected.append(candidate)
+
+				if len(collected) >= count:
+					return True
+		return False
+
+	if seed:
+		take(suggestions(seed))
+
+	if len(collected) < count and take(trending_queries()):
+		return collected[:count]
+
+	if len(collected) < count:
+		take(wikipedia_topics())
+
+	# Expand what we have until the count is met. Iterating over a snapshot
+	# because take() appends to the same list.
+	for term in list(collected):
+		if len(collected) >= count:
+			break
+
+		take(suggestions(term))
+
+	# Nothing reachable: let the caller decide, rather than typing junk.
+	return collected[:count]

--- a/src/rewards_tasks.py
+++ b/src/rewards_tasks.py
@@ -10,7 +10,7 @@ from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.common.exceptions import StaleElementReferenceException, TimeoutException, NoSuchElementException
 import tab_utils
-import llm_utils
+import queries
 import mouse_trajectory
 import mimic_typing
 import element_selectors
@@ -93,7 +93,7 @@ class RewardsTaskUtils:
 
 		for card in explore_on_bing_links:
 			desc = self.elements.extract_card_descriptions(card)
-			query = llm_utils.get_search_query_from_task_description(desc)
+			query = queries.search_query_for_task(desc)
 
 			self.move_to_and_click(card)
 			self.tab_utils.switch_to_other_tab()
@@ -220,9 +220,7 @@ class RewardsTaskUtils:
 		# search bar should be auto-focused
 
 		for i, query in enumerate(
-			llm_utils.get_related_search_queries(
-				llm_utils.get_random_noun(), num_queries=count
-			)
+			queries.related_queries(count)
 		):
 			self.keyboard.send_keys(f"{query} -noai{Keys.ENTER}")
 

--- a/src/rewards_tasks.py
+++ b/src/rewards_tasks.py
@@ -1,4 +1,5 @@
 import logging
+import log_utils
 import os
 import random
 import time
@@ -284,12 +285,8 @@ class RewardsTaskUtils:
 			except (NoSuchElementException, TimeoutException) as exc:
 				logger.warning("[SKIP] %s: not available in this UI variant (%s)", name, type(exc).__name__)
 			except Exception as exc:
-				# A selenium exception carries the whole msedgedriver stacktrace
-				# in str(), tens of lines of it, so keep the summary to the
-				# first line and let the traceback on debug hold the rest.
-				message = str(exc).strip().splitlines()
 				logger.error(
-					"[FAIL] %s: %s: %s", name, type(exc).__name__, message[0] if message else "",
+					"[FAIL] %s: %s: %s", name, type(exc).__name__, log_utils.exception_summary(exc),
 					exc_info=logger.isEnabledFor(logging.DEBUG)
 				)
 

--- a/src/rewards_tasks.py
+++ b/src/rewards_tasks.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import random
 import time
@@ -16,6 +17,8 @@ import mimic_typing
 import element_selectors
 
 VISUAL_SEARCH_IMAGE_PATH = os.path.abspath("visual_search.jpg")
+
+logger = logging.getLogger(__name__)
 
 class RewardsTaskUtils:
 	def __init__(self, driver: webdriver.Edge):
@@ -113,7 +116,10 @@ class RewardsTaskUtils:
 
 		for card in explore_on_bing_links:
 			if not self.elements.card_is_complete(card):
-				print(f"[WARNING] Explore on Bing Card [desc={self.elements.extract_card_descriptions(card)!r}] is not complete after searching. Please check manually.")
+				logger.warning(
+					"Explore on Bing Card [desc=%r] is not complete after searching. Please check manually.",
+					self.elements.extract_card_descriptions(card)
+				)
 
 	def complete_visual_search(self):
 		self.switch_to_earn_page()
@@ -154,7 +160,10 @@ class RewardsTaskUtils:
 
 		for card in misc_cards:
 			if not self.elements.card_is_complete(card) and self.elements.get_card_point_value(card) > 0:
-				print(f"[WARNING] Misc Card [desc={self.elements.extract_card_descriptions(card)!r}] is not complete after clicking. Please check manually.")
+				logger.warning(
+					"Misc Card [desc=%r] is not complete after clicking. Please check manually.",
+					self.elements.extract_card_descriptions(card)
+				)
 
 		self.tab_utils.close_all_other_tabs()
 
@@ -170,7 +179,7 @@ class RewardsTaskUtils:
 		# Measure, search, measure again.
 		points_earned, max_pts = self.read_search_points()
 
-		print(f"[INFO] Search points before: {points_earned}/{max_pts}")
+		logger.info("Search points before: %s/%s", points_earned, max_pts)
 
 		for round_number in range(1, max_rounds + 1):
 			if points_earned >= max_pts:
@@ -184,16 +193,19 @@ class RewardsTaskUtils:
 			previous = points_earned
 			points_earned, max_pts = self.read_search_points()
 
-			print(f"[INFO] Round {round_number}: {searches} searches -> {points_earned}/{max_pts}")
+			logger.info(
+				"Round %s: %s searches -> %s/%s",
+				round_number, searches, points_earned, max_pts
+			)
 
 			if points_earned <= previous:
-				print("[WARNING] Round produced no points, stopping instead of searching pointlessly.")
+				logger.warning("Round produced no points, stopping instead of searching pointlessly.")
 				break
 
 		if points_earned < max_pts:
-			print(f"[WARNING] Search quota not filled: {points_earned}/{max_pts}")
+			logger.warning("Search quota not filled: %s/%s", points_earned, max_pts)
 		else:
-			print(f"Search quota complete: {points_earned}/{max_pts}")
+			logger.info("Search quota complete: %s/%s", points_earned, max_pts)
 
 	def read_search_points(self):
 		"""Open the points breakdown, read the Bing search row, close it again."""
@@ -230,7 +242,10 @@ class RewardsTaskUtils:
 
 			try: self.wait_for_then_click(self.elements.get_clear_bing_search_query_button)
 			except StaleElementReferenceException:
-				print(f"[WARNING] StaleElementReferenceException when trying to click the clear button for query {i+1}. Trying again...")
+				logger.warning(
+					"StaleElementReferenceException when trying to click the clear button for query %s. Trying again...",
+					i + 1
+				)
 				self.wait_for_then_click(self.elements.get_clear_bing_search_query_button)
 
 		self.driver.get("https://rewards.bing.com/")
@@ -244,7 +259,7 @@ class RewardsTaskUtils:
 		try:
 			self.wait_for_then_click(self.elements.get_claim_bonus_points_button)
 		except TimeoutException:
-			print("[WARNING] Could not find the 'Claim Bonus Points' button. There are likely no bonus points to claim at this time.")
+			logger.warning("Could not find the 'Claim Bonus Points' button. There are likely no bonus points to claim at this time.")
 
 	def complete_all_tasks(self):
 		# Each task is run independently. The Rewards UI differs by market and
@@ -260,13 +275,23 @@ class RewardsTaskUtils:
 		)
 
 		for name, step in steps:
+			# The tags stay in the message rather than being folded into the
+			# level, they are the per-task outcome summary and reading a run
+			# means scanning for them.
 			try:
 				step()
-				print(f"[OK] {name}")
+				logger.info("[OK] %s", name)
 			except (NoSuchElementException, TimeoutException) as exc:
-				print(f"[SKIP] {name}: not available in this UI variant ({type(exc).__name__})")
+				logger.warning("[SKIP] %s: not available in this UI variant (%s)", name, type(exc).__name__)
 			except Exception as exc:
-				print(f"[FAIL] {name}: {type(exc).__name__}: {exc}")
+				# A selenium exception carries the whole msedgedriver stacktrace
+				# in str(), tens of lines of it, so keep the summary to the
+				# first line and let the traceback on debug hold the rest.
+				message = str(exc).strip().splitlines()
+				logger.error(
+					"[FAIL] %s: %s: %s", name, type(exc).__name__, message[0] if message else "",
+					exc_info=logger.isEnabledFor(logging.DEBUG)
+				)
 
 			# Leave a clean tab state behind for the next task.
 			try:

--- a/src/rewards_tasks.py
+++ b/src/rewards_tasks.py
@@ -81,7 +81,10 @@ class RewardsTaskUtils:
 		except TimeoutException:
 			daily_set_links = self.elements.get_daily_set_elements()
 
-			print(f"[WARNING] Daily set panel only shows {len(daily_set_links)} of {expected_activities} activities")
+			logger.warning(
+				"Daily set panel only shows %s of %s activities",
+				len(daily_set_links), expected_activities
+			)
 
 		# Re-read the panel per index: clicking an activity can re-render it and
 		# stale the captured references.

--- a/src/tab_utils.py
+++ b/src/tab_utils.py
@@ -1,5 +1,8 @@
+import logging
 from selenium.common.exceptions import WebDriverException, JavascriptException
 from selenium import webdriver
+
+logger = logging.getLogger(__name__)
 
 GHOST_TAB_URLS = (
 	"https://ntp.msn.com/edge/ntp?locale=en-US&title=New%20tab&fre=1&dsp=1&sp=Bing&feed_dis=always&en_widget_reg=false&prerender=1&PC=U531", # has fre
@@ -30,7 +33,7 @@ document.dispatchEvent(new Event('visibilitychange'));
 				self.driver.switch_to.window(handle)
 
 				if self.driver.current_url in GHOST_TAB_URLS:
-					print(f"[INFO] Found ghost tab with handle {handle} and URL {self.driver.current_url}.")
+					logger.info("Found ghost tab with handle %s and URL %s.", handle, self.driver.current_url)
 					continue
 
 				self.ensure_focus()
@@ -47,17 +50,17 @@ document.dispatchEvent(new Event('visibilitychange'));
 				self.driver.switch_to.window(handle)
 
 				if self.driver.current_url in GHOST_TAB_URLS:
-					print(f"[INFO] Found ghost tab with handle {handle} and URL {self.driver.current_url}, not closing.")
+					logger.info("Found ghost tab with handle %s and URL %s, not closing.", handle, self.driver.current_url)
 					continue
 
 				tab_url = self.driver.current_url
 
 				try:
 					self.driver.close()
-					print(f"[INFO] Closed tab with handle {handle} and URL {tab_url}.")
+					logger.info("Closed tab with handle %s and URL %s.", handle, tab_url)
 
 				except WebDriverException:
-					print(f"[WARNING] Could not close tab with handle {handle} and URL {tab_url}.")
+					logger.warning("Could not close tab with handle %s and URL %s.", handle, tab_url)
 					self.problematic_tabs.add(handle)
 					pass
 

--- a/src/tab_utils.py
+++ b/src/tab_utils.py
@@ -33,7 +33,7 @@ document.dispatchEvent(new Event('visibilitychange'));
 				self.driver.switch_to.window(handle)
 
 				if self.driver.current_url in GHOST_TAB_URLS:
-					logger.info("Found ghost tab with handle %s and URL %s.", handle, self.driver.current_url)
+					logger.debug("Found ghost tab with handle %s and URL %s.", handle, self.driver.current_url)
 					continue
 
 				self.ensure_focus()
@@ -50,14 +50,18 @@ document.dispatchEvent(new Event('visibilitychange'));
 				self.driver.switch_to.window(handle)
 
 				if self.driver.current_url in GHOST_TAB_URLS:
-					logger.info("Found ghost tab with handle %s and URL %s, not closing.", handle, self.driver.current_url)
+					logger.debug("Found ghost tab with handle %s and URL %s, not closing.", handle, self.driver.current_url)
 					continue
 
 				tab_url = self.driver.current_url
 
 				try:
 					self.driver.close()
-					logger.info("Closed tab with handle %s and URL %s.", handle, tab_url)
+					# Routine bookkeeping, one line per tab. At info it drowned
+					# the task summary: 19 of the 33 records in a full run were
+					# these. The warning below stays at warning, a tab that will
+					# not close is a real problem.
+					logger.debug("Closed tab with handle %s and URL %s.", handle, tab_url)
 
 				except WebDriverException:
 					logger.warning("Could not close tab with handle %s and URL %s.", handle, tab_url)

--- a/tests/test_multi_account.py
+++ b/tests/test_multi_account.py
@@ -1,49 +1,51 @@
-"""Checks for REWARDS_ACCOUNTS.
+"""Tests for running more than one account in a single run.
 
-Five layers, cheapest first:
+Names become directory names, so most of these are about refusing one that
+would resolve somewhere other than where it reads: `..`, an absolute path, and
+the trailing dot Win32 strips but Python's normalisation does not. The rest
+cover the run loop, where one account failing used to end the batch and take
+the remaining accounts with it.
 
-    1. which accounts a configuration produces
-    2. the flags each one hands Edge
-    3. the run loop's ordering, skip-on-failure and exit codes
-    4. one account failing every way it can, without ending the batch
-    5. two real Edge profiles holding two independent, persistent identities
+None of these need a browser. The last case does, and starts Edge twice to show
+that two profiles hold two independent, persistent identities, so it is opt in:
 
-Layers 1 to 4 are pure and need nothing installed. Layer 4 drives the real
-run loop with a stand-in for the browser, so the code under test is the
-shipped one and only selenium is replaced. Layer 5 starts Edge twice and
-reaches bing.com, so it is opt in:
-
-    python tests/test_multi_account.py            # layers 1-4
-    python tests/test_multi_account.py --browser  # all five
-
-Layer 5 is the one that answers "does multi-account work". Two profiles must
-end up with two different identities, and each must keep its own across a
-restart, because that is what a per-account sign-in is made of. It uses
-bing.com's own MUID cookie rather than an injected one: a cookie added through
-webdriver is not written to the profile the way a Set-Cookie is, so it proves
-nothing about a sign-in surviving.
+	python -m unittest discover -s tests
+	REWARDS_BROWSER_TESTS=1 python -m unittest discover -s tests
 """
 
 import logging
 import os
 import shutil
 import sys
+import unittest
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-FAILURES = []
+from selenium.common.exceptions import (
+	NoSuchDriverException,
+	SessionNotCreatedException,
+	WebDriverException,
+)
 
+import accounts
+import main
+from constants import USER_DATA_DIR
 
-def check(label, got, want):
-	if got == want:
-		print(f"  ok    {label}")
-
-		return True
-
-	print(f"  FAIL  {label}\n          got  {got!r}\n          want {want!r}")
-	FAILURES.append(label)
-
-	return False
+# Names that have to be refused, with the reason each one is not simply a
+# directory sitting under data-dir.
+REFUSED_NAMES = [
+	# relative traversal
+	"..", ".", "../escape", "..\\escape", "a/b", "a\\b",
+	# absolute, drive relative and UNC
+	"/etc", "\\", "/", "C:", "C:\\Windows", "\\\\server\\share",
+	# expanded by a shell somewhere else, not here
+	"~", "%TEMP%", "$HOME",
+	# Win32 strips a trailing dot from a path component and Python does not, so
+	# "personal." is the "personal" directory and "..." is data-dir itself
+	"...", "....", "personal.", "personal..",
+	# shell and filesystem metacharacters
+	"a b", "a:b", "a;b", "a|b", "a*b", "a?b", "a<b",
+]
 
 
 def accounts_for(value):
@@ -56,202 +58,155 @@ def accounts_for(value):
 	return accounts.configured()
 
 
-# --------------------------------------------------------------------------
-# 1. which accounts a configuration produces
-# --------------------------------------------------------------------------
+class EnvironmentTestCase(unittest.TestCase):
+	"""Restores everything these tests reach into, so ordering cannot matter."""
 
-def test_configuration():
-	print("\n[1] account configuration")
-
-	default = accounts_for(None)
-	check("unset gives one account", [a.name for a in default], ["default"])
-	check("unset uses the existing profile directory", default[0].user_data_dir, USER_DATA_DIR)
-	check("unset is the default profile", default[0].is_default, True)
-
-	check("two names, in order", [a.name for a in accounts_for("personal,spare")], ["personal", "spare"])
-	check("surrounding whitespace ignored", [a.name for a in accounts_for(" personal , spare ")], ["personal", "spare"])
-	check("empty entries dropped", [a.name for a in accounts_for("personal,,spare,")], ["personal", "spare"])
-	check("blank value falls back to default", [a.name for a in accounts_for("   ")], ["default"])
-	check("duplicates collapse, case insensitively", [a.name for a in accounts_for("personal,PERSONAL,spare")], ["personal", "spare"])
-
-	# Names become directory names. Anything that resolves outside the profile
-	# directory, or onto a directory another entry already owns, has to be
-	# refused rather than quietly writing somewhere else.
-	refused = [
-		# relative traversal
-		"..", ".", "../escape", "..\\escape", "a/b", "a\\b",
-		# absolute, drive-relative and UNC
-		"/etc", "\\", "/", "C:", "C:\\Windows", "\\\\server\\share",
-		# expanded elsewhere, not here
-		"~", "%TEMP%", "$HOME",
-		# Win32 strips trailing dots, so these are not the directories they read
-		# as: "personal." is "personal", and "..." is data-dir itself
-		"...", "....", "personal.", "personal..",
-		# shell and filesystem metacharacters
-		"a b", "a:b", "a;b", "a|b", "a*b", "a?b", "a<b",
-	]
-
-	for name in refused:
-		try:
-			accounts_for(f"good,{name}")
-			rejected = False
-		except ValueError:
-			rejected = True
-
-		check(f"refused as a directory name: {name!r}", rejected, True)
-
-	# The leading dot is fine, it is only the trailing one that moves.
-	check("a leading dot is still a usable name", [a.name for a in accounts_for(".hidden")], [".hidden"])
-
-	named = accounts_for("personal,spare")
-	check("one directory per account", len({a.user_data_dir for a in named}), 2)
-
-	# Distinct strings are not enough. Two names can spell one directory, which
-	# is what the trailing dot did, so compare where the paths actually land.
-	check(
-		"one directory per account after the filesystem resolves them",
-		len({os.path.realpath(a.user_data_dir) for a in named}), 2
-	)
-
-	root = os.path.realpath(USER_DATA_DIR)
-	inside = all(
-		os.path.commonpath([root, os.path.realpath(a.user_data_dir)]) == root
-		and os.path.realpath(a.user_data_dir) != root
-		for a in named
-	)
-	check("every directory sits under the profile directory", inside, True)
-	check("named accounts are not the default profile", [a.is_default for a in named], [False, False])
+	def setUp(self):
+		self.addCleanup(os.environ.pop, accounts.ENV_VAR, None)
 
 
-# --------------------------------------------------------------------------
-# 2. the flags each one hands Edge
-# --------------------------------------------------------------------------
+class TestAccountConfiguration(EnvironmentTestCase):
+	def test_unset_is_the_existing_single_profile(self):
+		configured = accounts_for(None)
 
-def test_options():
-	print("\n[2] the flags Edge is handed")
+		self.assertEqual([a.name for a in configured], ["default"])
+		self.assertEqual(configured[0].user_data_dir, USER_DATA_DIR)
+		self.assertTrue(configured[0].is_default)
 
-	seen = []
+	def test_blank_falls_back_to_the_single_profile(self):
+		self.assertEqual([a.name for a in accounts_for("   ")], ["default"])
 
-	for account in accounts_for("personal,spare"):
-		args = main.build_options(account).arguments
-		user_data = [a for a in args if a.startswith("--user-data-dir=")]
-		profile = [a for a in args if a.startswith("--profile-directory=")]
+	def test_names_are_taken_in_order(self):
+		self.assertEqual([a.name for a in accounts_for("personal,spare")], ["personal", "spare"])
 
-		check(f"{account.name}: exactly one --user-data-dir", len(user_data), 1)
-		check(f"{account.name}: exactly one --profile-directory", len(profile), 1)
-		seen.append(user_data[0])
+	def test_surrounding_whitespace_and_empty_entries_are_ignored(self):
+		self.assertEqual([a.name for a in accounts_for(" personal , spare ")], ["personal", "spare"])
+		self.assertEqual([a.name for a in accounts_for("personal,,spare,")], ["personal", "spare"])
 
-	check("the two profiles differ on the command line", len(set(seen)), 2)
+	def test_duplicates_collapse_case_insensitively(self):
+		# Running the same profile twice earns nothing the second time and
+		# doubles the length of the run.
+		self.assertEqual(
+			[a.name for a in accounts_for("personal,PERSONAL,spare")], ["personal", "spare"]
+		)
+
+	def test_unusable_directory_names_are_refused(self):
+		for name in REFUSED_NAMES:
+			with self.subTest(name=name):
+				with self.assertRaises(ValueError):
+					accounts_for(f"good,{name}")
+
+	def test_a_leading_dot_is_still_usable(self):
+		# Only the trailing dot moves the directory.
+		self.assertEqual([a.name for a in accounts_for(".hidden")], [".hidden"])
+
+	def test_each_account_gets_its_own_directory(self):
+		named = accounts_for("personal,spare")
+
+		self.assertEqual(len({a.user_data_dir for a in named}), 2)
+		# Distinct strings are not enough: two names can spell one directory,
+		# which is what the trailing dot did, so compare where they land.
+		self.assertEqual(len({os.path.realpath(a.user_data_dir) for a in named}), 2)
+
+	def test_every_directory_sits_under_the_profile_directory(self):
+		root = os.path.realpath(USER_DATA_DIR)
+
+		for account in accounts_for("personal,spare"):
+			with self.subTest(account=account.name):
+				resolved = os.path.realpath(account.user_data_dir)
+
+				self.assertEqual(os.path.commonpath([root, resolved]), root)
+				self.assertNotEqual(resolved, root)
+				self.assertFalse(account.is_default)
 
 
-# --------------------------------------------------------------------------
-# 3. the run loop
-# --------------------------------------------------------------------------
+class TestEdgeOptions(EnvironmentTestCase):
+	def test_each_account_is_handed_its_own_profile(self):
+		seen = []
 
-def test_run_loop():
-	print("\n[3] the run loop")
+		for account in accounts_for("personal,spare"):
+			arguments = main.build_options(account).arguments
+			user_data = [a for a in arguments if a.startswith("--user-data-dir=")]
+			profile = [a for a in arguments if a.startswith("--profile-directory=")]
 
-	accounts_for("personal,spare")
-	os.environ["REWARDS_HEADLESS"] = "1"
-	main.HEADLESS = True  # so main() does not wait on input()
+			with self.subTest(account=account.name):
+				self.assertEqual(len(user_data), 1)
+				self.assertEqual(len(profile), 1)
 
-	real = main.run_account
-	calls = []
+			seen.append(user_data[0])
 
-	try:
-		# The first profile fails to start; the second must still run.
-		main.run_account = lambda a: (calls.append(a.name), a.name != "personal")[1]
-		code = main.main()
+		self.assertEqual(len(set(seen)), 2)
 
-		check("every account attempted, in order", calls, ["personal", "spare"])
-		check("a profile that fails to start does not end the run", len(calls), 2)
-		check("exit code 0 while at least one ran", code, 0)
 
-		calls.clear()
-		main.run_account = lambda a: (calls.append(a.name), False)[1]
-		check("exit code 1 when none ran", main.main(), 1)
+class RunLoopTestCase(EnvironmentTestCase):
+	"""main() drives real browsers, so both entry points are replaced here."""
 
-		calls.clear()
-		main.run_account = lambda a: (calls.append(a.name), True)[1]
+	def setUp(self):
+		super().setUp()
+
+		# main() waits on input() when it is not headless, which would hang.
+		headless = main.HEADLESS
+		main.HEADLESS = True
+		self.addCleanup(setattr, main, "HEADLESS", headless)
+
+		# main() reports per account at info, and the failure paths at error, by
+		# design. The assertions are what reports the outcome here, so keep the
+		# suite's own output to what unittest prints.
+		logging.disable(logging.CRITICAL)
+		self.addCleanup(logging.disable, logging.NOTSET)
+
+
+class TestRunLoop(RunLoopTestCase):
+	def setUp(self):
+		super().setUp()
+
+		self.calls = []
+		real = main.run_account
+		self.addCleanup(setattr, main, "run_account", real)
+
+	def _record(self, started):
+		def run_account(account):
+			self.calls.append(account.name)
+
+			return started(account.name)
+
+		main.run_account = run_account
+
+	def test_a_profile_that_fails_to_start_does_not_end_the_run(self):
+		accounts_for("personal,spare")
+		self._record(lambda name: name != "personal")
+
+		self.assertEqual(main.main(), 0)
+		self.assertEqual(self.calls, ["personal", "spare"])
+
+	def test_exit_code_is_one_when_no_account_ran(self):
+		accounts_for("personal,spare")
+		self._record(lambda name: False)
+
+		self.assertEqual(main.main(), 1)
+		self.assertEqual(self.calls, ["personal", "spare"])
+
+	def test_unset_still_runs_the_single_profile(self):
 		accounts_for(None)
-		check("unset still runs the single profile", (main.main(), calls), (0, ["default"]))
-	finally:
-		main.run_account = real
+		self._record(lambda name: True)
+
+		self.assertEqual(main.main(), 0)
+		self.assertEqual(self.calls, ["default"])
 
 
-# --------------------------------------------------------------------------
-# 4. one account failing, without ending the batch
-# --------------------------------------------------------------------------
+class TestFailureIsolation(RunLoopTestCase):
+	"""One account failing, every way it can, without ending the batch.
 
-def failing_run(fail_at, exc):
-	"""Three accounts through the real run loop, with the middle one failing.
-
-	Only selenium is replaced. run_account and main() are the shipped ones, so
-	what is measured is where their exception handling actually reaches.
+	Only selenium is replaced: run_account and main() are the shipped ones, so
+	what is measured is where their exception handling actually reaches. Before
+	this, only "profile already open" was handled by name and everything else
+	took the remaining accounts with it.
 	"""
-	started, quit_cleanly = [], []
 
-	def account_of(options):
-		flag = next(a for a in options.arguments if a.startswith("--user-data-dir="))
-
-		return os.path.basename(flag.split("=", 1)[1])
-
-	class Driver:
-		def __init__(self, options):
-			self.name = account_of(options)
-			started.append(self.name)
-
-			if self.name == "two" and fail_at == "start":
-				raise exc
-
-		def quit(self):
-			if self.name == "two" and fail_at == "quit":
-				raise exc
-
-			quit_cleanly.append(self.name)
-
-	class Tasks:
-		def __init__(self, driver):
-			self.driver = driver
-
-			if driver.name == "two" and fail_at == "connect":
-				raise exc
-
-		def complete_all_tasks(self):
-			if self.driver.name == "two" and fail_at == "tasks":
-				raise exc
-
-	real_edge, real_tasks = main.webdriver.Edge, main.rewards_tasks.RewardsTaskUtils
-	main.webdriver.Edge, main.rewards_tasks.RewardsTaskUtils = Driver, Tasks
-
-	try:
-		accounts_for("one,two,three")
-		outcome = main.main()
-	except BaseException as raised:  # noqa: BLE001 - the point is to notice it
-		outcome = f"raised {type(raised).__name__}"
-	finally:
-		main.webdriver.Edge, main.rewards_tasks.RewardsTaskUtils = real_edge, real_tasks
-
-	return started, quit_cleanly, outcome
-
-
-def test_failure_isolation():
-	print("\n[4] one account failing, without ending the batch")
-
-	os.environ["REWARDS_HEADLESS"] = "1"
-	main.HEADLESS = True
-
-	# Every way the middle account can go wrong. Only the first of these was
-	# handled by name; the rest reached main() and took account three with them.
-	from selenium.common.exceptions import (
-		NoSuchDriverException,
-		SessionNotCreatedException,
-		WebDriverException,
-	)
-
-	cases = [
+	# (label, where it fails, the exception raised)
+	CASES = [
 		("the profile is already open", "start", SessionNotCreatedException("profile in use")),
-		("the driver will not start", "start", WebDriverException("browser and driver version mismatch")),
+		("the driver will not start", "start", WebDriverException("driver version mismatch")),
 		("there is no driver installed", "start", NoSuchDriverException("msedgedriver not found")),
 		("the profile directory is unwritable", "start", PermissionError(13, "Permission denied")),
 		("the first page never loads", "connect", WebDriverException("net::ERR_NAME_NOT_RESOLVED")),
@@ -259,101 +214,130 @@ def test_failure_isolation():
 		("the browser will not shut down", "quit", WebDriverException("browser already gone")),
 	]
 
-	# The failure paths log at error level by design; the checks below are what
-	# reports the outcome, so keep the output readable.
-	logging.disable(logging.CRITICAL)
+	def setUp(self):
+		super().setUp()
 
-	try:
-		for label, fail_at, exc in cases:
-			started, quit_cleanly, outcome = failing_run(fail_at, exc)
+		edge, tasks = main.webdriver.Edge, main.rewards_tasks.RewardsTaskUtils
+		self.addCleanup(setattr, main.webdriver, "Edge", edge)
+		self.addCleanup(setattr, main.rewards_tasks, "RewardsTaskUtils", tasks)
 
-			check(f"{label}: the other accounts still run", started, ["one", "two", "three"])
-			check(f"{label}: main() still returns an exit code", outcome, 0)
+	def _install(self, fail_at, exc, started, quit_cleanly):
+		def account_of(options):
+			flag = next(a for a in options.arguments if a.startswith("--user-data-dir="))
 
-			# Whatever went wrong, the browsers that did start have to be shut
-			# down, or their profiles stay locked against the next run.
-			expected_quit = ["one", "three"] if fail_at in ("start", "quit") else ["one", "two", "three"]
-			check(f"{label}: every started browser was closed", quit_cleanly, expected_quit)
-	finally:
-		logging.disable(logging.NOTSET)
+			return os.path.basename(flag.split("=", 1)[1])
 
-	# A lone account is the unset, unchanged path. Its failure has nothing left
-	# to protect, so it must still come out as a failing exit code rather than
-	# being swallowed into a success.
-	accounts_for(None)
-	real = main.run_account
-	logging.disable(logging.CRITICAL)
+		class Driver:
+			def __init__(self, options):
+				self.name = account_of(options)
+				started.append(self.name)
 
-	try:
+				if self.name == "two" and fail_at == "start":
+					raise exc
+
+			def quit(self):
+				if self.name == "two" and fail_at == "quit":
+					raise exc
+
+				quit_cleanly.append(self.name)
+
+		class Tasks:
+			def __init__(self, driver):
+				self.driver = driver
+
+				if driver.name == "two" and fail_at == "connect":
+					raise exc
+
+			def complete_all_tasks(self):
+				if self.driver.name == "two" and fail_at == "tasks":
+					raise exc
+
+		main.webdriver.Edge = Driver
+		main.rewards_tasks.RewardsTaskUtils = Tasks
+
+	def test_the_remaining_accounts_still_run(self):
+		for label, fail_at, exc in self.CASES:
+			with self.subTest(case=label):
+				started, quit_cleanly = [], []
+				self._install(fail_at, exc, started, quit_cleanly)
+				accounts_for("one,two,three")
+
+				self.assertEqual(main.main(), 0)
+				self.assertEqual(started, ["one", "two", "three"])
+
+				# Whatever went wrong, a browser that started has to be shut
+				# down or its profile stays locked against the next run.
+				expected = ["one", "three"] if fail_at in ("start", "quit") else ["one", "two", "three"]
+				self.assertEqual(quit_cleanly, expected)
+
+	def test_a_lone_accounts_failure_is_still_a_failing_exit_code(self):
+		# The unset, unchanged path. Its failure has nothing left to protect, so
+		# it must not be swallowed into a success.
+		accounts_for(None)
+		real = main.run_account
+		self.addCleanup(setattr, main, "run_account", real)
+
 		def boom(_):
 			raise WebDriverException("chrome not reachable")
 
 		main.run_account = boom
-		check("a lone account's failure is still exit code 1", main.main(), 1)
-	finally:
-		main.run_account = real
-		logging.disable(logging.NOTSET)
+
+		self.assertEqual(main.main(), 1)
 
 
-# --------------------------------------------------------------------------
-# 5. two real profiles, two independent identities
-# --------------------------------------------------------------------------
+@unittest.skipUnless(
+	os.environ.get("REWARDS_BROWSER_TESTS"),
+	"starts Edge twice; set REWARDS_BROWSER_TESTS=1 to run",
+)
+class TestTwoRealProfiles(EnvironmentTestCase):
+	"""Two profiles, two independent identities, each surviving a restart.
 
-def identity_of(account):
-	"""bing.com's MUID for this profile: server set, and persistent."""
-	from selenium import webdriver
+	Keyed on bing.com's own MUID rather than an injected cookie: one added
+	through webdriver is not written to the profile the way a Set-Cookie is, so
+	it would prove nothing about a sign-in outliving the browser.
+	"""
 
-	driver = webdriver.Edge(options=main.build_options(account))
+	def setUp(self):
+		super().setUp()
 
-	try:
-		driver.get("https://www.bing.com")
-		cookie = driver.get_cookie("MUID")
+		self.first, self.second = accounts_for("mat_a,mat_b")
 
-		return cookie["value"] if cookie else None
-	finally:
-		driver.quit()
+		for account in (self.first, self.second):
+			self.addCleanup(shutil.rmtree, account.user_data_dir, ignore_errors=True)
 
+	def identity_of(self, account):
+		from selenium import webdriver
 
-def test_real_profiles():
-	print("\n[5] two real Edge profiles")
+		driver = webdriver.Edge(options=main.build_options(account))
 
-	first, second = accounts_for("mat_a,mat_b")
+		try:
+			driver.get("https://www.bing.com")
+			cookie = driver.get_cookie("MUID")
 
-	try:
-		a_before = identity_of(first)
-		b_before = identity_of(second)
+			return cookie["value"] if cookie else None
+		finally:
+			driver.quit()
 
-		check("first profile gets an identity", a_before is not None, True)
-		check("second profile gets an identity", b_before is not None, True)
-		check("the two profiles are different identities", a_before != b_before, True)
+	def test_two_profiles_hold_two_persistent_identities(self):
+		first_id = self.identity_of(self.first)
+		second_id = self.identity_of(self.second)
 
-		check("first profile keeps its identity across a restart", identity_of(first), a_before)
-		check("second profile keeps its identity across a restart", identity_of(second), b_before)
-		check("and they are still distinct", identity_of(first) != identity_of(second), True)
-		check("both directories exist", [os.path.isdir(a.user_data_dir) for a in (first, second)], [True, True])
-		check(
-			"and they are two directories, not one",
-			len({os.path.realpath(a.user_data_dir) for a in (first, second)}), 2
+		self.assertIsNotNone(first_id)
+		self.assertIsNotNone(second_id)
+		self.assertNotEqual(first_id, second_id)
+
+		# The point of a profile per account: the identity has to outlive the
+		# browser, or a sign-in would not either.
+		self.assertEqual(self.identity_of(self.first), first_id)
+		self.assertEqual(self.identity_of(self.second), second_id)
+
+		for account in (self.first, self.second):
+			self.assertTrue(os.path.isdir(account.user_data_dir))
+
+		self.assertEqual(
+			len({os.path.realpath(a.user_data_dir) for a in (self.first, self.second)}), 2
 		)
-	finally:
-		for account in (first, second):
-			shutil.rmtree(account.user_data_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":
-	import accounts
-	import main
-	from constants import USER_DATA_DIR
-
-	test_configuration()
-	test_options()
-	test_run_loop()
-	test_failure_isolation()
-
-	if "--browser" in sys.argv:
-		test_real_profiles()
-	else:
-		print("\n[5] skipped, pass --browser to start Edge")
-
-	print("\n" + (f"{len(FAILURES)} failed: " + "; ".join(FAILURES) if FAILURES else "all checks passed"))
-	sys.exit(1 if FAILURES else 0)
+	unittest.main()

--- a/tests/test_multi_account.py
+++ b/tests/test_multi_account.py
@@ -1,0 +1,359 @@
+"""Checks for REWARDS_ACCOUNTS.
+
+Five layers, cheapest first:
+
+    1. which accounts a configuration produces
+    2. the flags each one hands Edge
+    3. the run loop's ordering, skip-on-failure and exit codes
+    4. one account failing every way it can, without ending the batch
+    5. two real Edge profiles holding two independent, persistent identities
+
+Layers 1 to 4 are pure and need nothing installed. Layer 4 drives the real
+run loop with a stand-in for the browser, so the code under test is the
+shipped one and only selenium is replaced. Layer 5 starts Edge twice and
+reaches bing.com, so it is opt in:
+
+    python tests/test_multi_account.py            # layers 1-4
+    python tests/test_multi_account.py --browser  # all five
+
+Layer 5 is the one that answers "does multi-account work". Two profiles must
+end up with two different identities, and each must keep its own across a
+restart, because that is what a per-account sign-in is made of. It uses
+bing.com's own MUID cookie rather than an injected one: a cookie added through
+webdriver is not written to the profile the way a Set-Cookie is, so it proves
+nothing about a sign-in surviving.
+"""
+
+import logging
+import os
+import shutil
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+
+FAILURES = []
+
+
+def check(label, got, want):
+	if got == want:
+		print(f"  ok    {label}")
+
+		return True
+
+	print(f"  FAIL  {label}\n          got  {got!r}\n          want {want!r}")
+	FAILURES.append(label)
+
+	return False
+
+
+def accounts_for(value):
+	"""configured() under a given REWARDS_ACCOUNTS, or ValueError."""
+	if value is None:
+		os.environ.pop(accounts.ENV_VAR, None)
+	else:
+		os.environ[accounts.ENV_VAR] = value
+
+	return accounts.configured()
+
+
+# --------------------------------------------------------------------------
+# 1. which accounts a configuration produces
+# --------------------------------------------------------------------------
+
+def test_configuration():
+	print("\n[1] account configuration")
+
+	default = accounts_for(None)
+	check("unset gives one account", [a.name for a in default], ["default"])
+	check("unset uses the existing profile directory", default[0].user_data_dir, USER_DATA_DIR)
+	check("unset is the default profile", default[0].is_default, True)
+
+	check("two names, in order", [a.name for a in accounts_for("personal,spare")], ["personal", "spare"])
+	check("surrounding whitespace ignored", [a.name for a in accounts_for(" personal , spare ")], ["personal", "spare"])
+	check("empty entries dropped", [a.name for a in accounts_for("personal,,spare,")], ["personal", "spare"])
+	check("blank value falls back to default", [a.name for a in accounts_for("   ")], ["default"])
+	check("duplicates collapse, case insensitively", [a.name for a in accounts_for("personal,PERSONAL,spare")], ["personal", "spare"])
+
+	# Names become directory names. Anything that resolves outside the profile
+	# directory, or onto a directory another entry already owns, has to be
+	# refused rather than quietly writing somewhere else.
+	refused = [
+		# relative traversal
+		"..", ".", "../escape", "..\\escape", "a/b", "a\\b",
+		# absolute, drive-relative and UNC
+		"/etc", "\\", "/", "C:", "C:\\Windows", "\\\\server\\share",
+		# expanded elsewhere, not here
+		"~", "%TEMP%", "$HOME",
+		# Win32 strips trailing dots, so these are not the directories they read
+		# as: "personal." is "personal", and "..." is data-dir itself
+		"...", "....", "personal.", "personal..",
+		# shell and filesystem metacharacters
+		"a b", "a:b", "a;b", "a|b", "a*b", "a?b", "a<b",
+	]
+
+	for name in refused:
+		try:
+			accounts_for(f"good,{name}")
+			rejected = False
+		except ValueError:
+			rejected = True
+
+		check(f"refused as a directory name: {name!r}", rejected, True)
+
+	# The leading dot is fine, it is only the trailing one that moves.
+	check("a leading dot is still a usable name", [a.name for a in accounts_for(".hidden")], [".hidden"])
+
+	named = accounts_for("personal,spare")
+	check("one directory per account", len({a.user_data_dir for a in named}), 2)
+
+	# Distinct strings are not enough. Two names can spell one directory, which
+	# is what the trailing dot did, so compare where the paths actually land.
+	check(
+		"one directory per account after the filesystem resolves them",
+		len({os.path.realpath(a.user_data_dir) for a in named}), 2
+	)
+
+	root = os.path.realpath(USER_DATA_DIR)
+	inside = all(
+		os.path.commonpath([root, os.path.realpath(a.user_data_dir)]) == root
+		and os.path.realpath(a.user_data_dir) != root
+		for a in named
+	)
+	check("every directory sits under the profile directory", inside, True)
+	check("named accounts are not the default profile", [a.is_default for a in named], [False, False])
+
+
+# --------------------------------------------------------------------------
+# 2. the flags each one hands Edge
+# --------------------------------------------------------------------------
+
+def test_options():
+	print("\n[2] the flags Edge is handed")
+
+	seen = []
+
+	for account in accounts_for("personal,spare"):
+		args = main.build_options(account).arguments
+		user_data = [a for a in args if a.startswith("--user-data-dir=")]
+		profile = [a for a in args if a.startswith("--profile-directory=")]
+
+		check(f"{account.name}: exactly one --user-data-dir", len(user_data), 1)
+		check(f"{account.name}: exactly one --profile-directory", len(profile), 1)
+		seen.append(user_data[0])
+
+	check("the two profiles differ on the command line", len(set(seen)), 2)
+
+
+# --------------------------------------------------------------------------
+# 3. the run loop
+# --------------------------------------------------------------------------
+
+def test_run_loop():
+	print("\n[3] the run loop")
+
+	accounts_for("personal,spare")
+	os.environ["REWARDS_HEADLESS"] = "1"
+	main.HEADLESS = True  # so main() does not wait on input()
+
+	real = main.run_account
+	calls = []
+
+	try:
+		# The first profile fails to start; the second must still run.
+		main.run_account = lambda a: (calls.append(a.name), a.name != "personal")[1]
+		code = main.main()
+
+		check("every account attempted, in order", calls, ["personal", "spare"])
+		check("a profile that fails to start does not end the run", len(calls), 2)
+		check("exit code 0 while at least one ran", code, 0)
+
+		calls.clear()
+		main.run_account = lambda a: (calls.append(a.name), False)[1]
+		check("exit code 1 when none ran", main.main(), 1)
+
+		calls.clear()
+		main.run_account = lambda a: (calls.append(a.name), True)[1]
+		accounts_for(None)
+		check("unset still runs the single profile", (main.main(), calls), (0, ["default"]))
+	finally:
+		main.run_account = real
+
+
+# --------------------------------------------------------------------------
+# 4. one account failing, without ending the batch
+# --------------------------------------------------------------------------
+
+def failing_run(fail_at, exc):
+	"""Three accounts through the real run loop, with the middle one failing.
+
+	Only selenium is replaced. run_account and main() are the shipped ones, so
+	what is measured is where their exception handling actually reaches.
+	"""
+	started, quit_cleanly = [], []
+
+	def account_of(options):
+		flag = next(a for a in options.arguments if a.startswith("--user-data-dir="))
+
+		return os.path.basename(flag.split("=", 1)[1])
+
+	class Driver:
+		def __init__(self, options):
+			self.name = account_of(options)
+			started.append(self.name)
+
+			if self.name == "two" and fail_at == "start":
+				raise exc
+
+		def quit(self):
+			if self.name == "two" and fail_at == "quit":
+				raise exc
+
+			quit_cleanly.append(self.name)
+
+	class Tasks:
+		def __init__(self, driver):
+			self.driver = driver
+
+			if driver.name == "two" and fail_at == "connect":
+				raise exc
+
+		def complete_all_tasks(self):
+			if self.driver.name == "two" and fail_at == "tasks":
+				raise exc
+
+	real_edge, real_tasks = main.webdriver.Edge, main.rewards_tasks.RewardsTaskUtils
+	main.webdriver.Edge, main.rewards_tasks.RewardsTaskUtils = Driver, Tasks
+
+	try:
+		accounts_for("one,two,three")
+		outcome = main.main()
+	except BaseException as raised:  # noqa: BLE001 - the point is to notice it
+		outcome = f"raised {type(raised).__name__}"
+	finally:
+		main.webdriver.Edge, main.rewards_tasks.RewardsTaskUtils = real_edge, real_tasks
+
+	return started, quit_cleanly, outcome
+
+
+def test_failure_isolation():
+	print("\n[4] one account failing, without ending the batch")
+
+	os.environ["REWARDS_HEADLESS"] = "1"
+	main.HEADLESS = True
+
+	# Every way the middle account can go wrong. Only the first of these was
+	# handled by name; the rest reached main() and took account three with them.
+	from selenium.common.exceptions import (
+		NoSuchDriverException,
+		SessionNotCreatedException,
+		WebDriverException,
+	)
+
+	cases = [
+		("the profile is already open", "start", SessionNotCreatedException("profile in use")),
+		("the driver will not start", "start", WebDriverException("browser and driver version mismatch")),
+		("there is no driver installed", "start", NoSuchDriverException("msedgedriver not found")),
+		("the profile directory is unwritable", "start", PermissionError(13, "Permission denied")),
+		("the first page never loads", "connect", WebDriverException("net::ERR_NAME_NOT_RESOLVED")),
+		("the browser dies mid-run", "tasks", WebDriverException("chrome not reachable")),
+		("the browser will not shut down", "quit", WebDriverException("browser already gone")),
+	]
+
+	# The failure paths log at error level by design; the checks below are what
+	# reports the outcome, so keep the output readable.
+	logging.disable(logging.CRITICAL)
+
+	try:
+		for label, fail_at, exc in cases:
+			started, quit_cleanly, outcome = failing_run(fail_at, exc)
+
+			check(f"{label}: the other accounts still run", started, ["one", "two", "three"])
+			check(f"{label}: main() still returns an exit code", outcome, 0)
+
+			# Whatever went wrong, the browsers that did start have to be shut
+			# down, or their profiles stay locked against the next run.
+			expected_quit = ["one", "three"] if fail_at in ("start", "quit") else ["one", "two", "three"]
+			check(f"{label}: every started browser was closed", quit_cleanly, expected_quit)
+	finally:
+		logging.disable(logging.NOTSET)
+
+	# A lone account is the unset, unchanged path. Its failure has nothing left
+	# to protect, so it must still come out as a failing exit code rather than
+	# being swallowed into a success.
+	accounts_for(None)
+	real = main.run_account
+	logging.disable(logging.CRITICAL)
+
+	try:
+		def boom(_):
+			raise WebDriverException("chrome not reachable")
+
+		main.run_account = boom
+		check("a lone account's failure is still exit code 1", main.main(), 1)
+	finally:
+		main.run_account = real
+		logging.disable(logging.NOTSET)
+
+
+# --------------------------------------------------------------------------
+# 5. two real profiles, two independent identities
+# --------------------------------------------------------------------------
+
+def identity_of(account):
+	"""bing.com's MUID for this profile: server set, and persistent."""
+	from selenium import webdriver
+
+	driver = webdriver.Edge(options=main.build_options(account))
+
+	try:
+		driver.get("https://www.bing.com")
+		cookie = driver.get_cookie("MUID")
+
+		return cookie["value"] if cookie else None
+	finally:
+		driver.quit()
+
+
+def test_real_profiles():
+	print("\n[5] two real Edge profiles")
+
+	first, second = accounts_for("mat_a,mat_b")
+
+	try:
+		a_before = identity_of(first)
+		b_before = identity_of(second)
+
+		check("first profile gets an identity", a_before is not None, True)
+		check("second profile gets an identity", b_before is not None, True)
+		check("the two profiles are different identities", a_before != b_before, True)
+
+		check("first profile keeps its identity across a restart", identity_of(first), a_before)
+		check("second profile keeps its identity across a restart", identity_of(second), b_before)
+		check("and they are still distinct", identity_of(first) != identity_of(second), True)
+		check("both directories exist", [os.path.isdir(a.user_data_dir) for a in (first, second)], [True, True])
+		check(
+			"and they are two directories, not one",
+			len({os.path.realpath(a.user_data_dir) for a in (first, second)}), 2
+		)
+	finally:
+		for account in (first, second):
+			shutil.rmtree(account.user_data_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+	import accounts
+	import main
+	from constants import USER_DATA_DIR
+
+	test_configuration()
+	test_options()
+	test_run_loop()
+	test_failure_isolation()
+
+	if "--browser" in sys.argv:
+		test_real_profiles()
+	else:
+		print("\n[5] skipped, pass --browser to start Edge")
+
+	print("\n" + (f"{len(FAILURES)} failed: " + "; ".join(FAILURES) if FAILURES else "all checks passed"))
+	sys.exit(1 if FAILURES else 0)


### PR DESCRIPTION
Closes #14. Supersedes #31 and #35, which are closed; everything in both is carried over here.

Four changes that all touch `src/main.py`, which is why they arrive together rather than as separate pull requests queued on the same file.

---

## 1. print to logging

The whole of #31, unchanged. `src/log_utils.py` holds a `setup_logging()` called once from `main.py`, each module keeps its own `logging.getLogger(__name__)`, stdlib only.

`[INFO]` and `[WARNING]` prefixes are dropped since the level carries them. `[OK]`, `[SKIP]` and `[FAIL]` stay in the message: they are the per-task outcome summary, not severities, and folding them into the level would erase the run summary.

Three things that came out of running it rather than reading it:

- **`str()` on a selenium exception carries the whole msedgedriver stacktrace.** Measured on one real `InvalidSelectorException`: `main` prints **28 lines** per `[FAIL]`, one of them blank. This keeps the first line, so one task stays one record, and the full stack is still attached when the level is debug.
- **Configuring the root logger switches on every library's output.** `httpx` emits an info line per LLM call. `print` never did that because it never touched logging, so a change meant to improve output would have made it noisier. `httpx`, `httpcore`, `urllib3` and `selenium` are pinned to WARNING. This was a real regression in the first draft, caught by a full run.
- **Tab bookkeeping moved to debug.** It was 19 of the 33 records in a full run, outnumbering the six task outcomes three to one. "Could not close" stays at warning.

`REWARDS_FARMER_LOG_LEVEL=DEBUG` attaches the traceback to every `[FAIL]`, which is the stack trace bug reports keep having to be asked for. `REWARDS_FARMER_LOG_FILE` writes the same output to disk. Both off by default.

## 2. A query source that is not a language model

Idea from TheNetsky/Microsoft-Rewards-Script, which #25 asked about. **No code from it: that project is GPL-3.0 and this one is MIT**, so only the approach crosses over.

The LLM has exactly two call sites here, both producing a short string to type into Bing. Everything the dependency costs, an Ollama account, cloud usage and the provider work in #15, is paid for search strings. Three keyless sources answer the same question: Google Trends RSS, Wikipedia most-read, and Bing autosuggest. Autosuggest is what makes chaining work, since asking Bing what follows a term returns queries Bing already expects.

Same cards, live account, side by side:

| card | llm | trends |
| --- | --- | --- |
| airport parking | best rates airport parking reservations | reserve airport parking best rates |
| checking vs savings | compare checking vs savings accounts rates | compare checking savings account options |
| cruise deals | best cruise deals and destinations | cruise deals destinations |

`QUERY_SOURCE=trends` selects it. **The default stays `llm`, so no existing setup changes.** Every source degrades to an empty list rather than raising, and both entry points fall back rather than failing a run.

Checked both directions from inside the container: with network, trends and Wikipedia and autosuggest all answer and a card produces `compare checking savings account options`; with `--network none`, every source returns empty, the quota path logs `falling back to the wordlist` and returns five nouns from `nouns.txt`, and `ollama` is never imported in either case.

## 3. More than one account

Rewards is per Microsoft account and the profile holds the sign-in, so an account here is a profile directory. `REWARDS_ACCOUNTS=personal,spare` gives each its own directory under the configured one. They run in sequence, and an account that fails is reported and skipped rather than ending the run.

Names are validated rather than trusted, since they become directory names: `../escape` is refused instead of quietly writing outside `data-dir`.

**Unset, a run uses the single profile exactly as before.**

### Measured on two real accounts

Two different Microsoft accounts, each signed into its own profile directory, one `REWARDS_ACCOUNTS=acct_a,acct_b` run in the container, points read from the dashboard before and after:

| | account A | account B |
| --- | --- | --- |
| tier | Member | Silver Member |
| available points | 0 → **260** | 3,093 → **3,183** |
| bing search quota | 0/25 → **25/25** | 0/50 → **45/50** |

`2/2 accounts ran`, exit code 0, one profile directory per name, and the two profiles kept distinct `MUID`s throughout. The accounts earned different amounts because they were in different states, not because the run treated them differently: A was new and had first-time task points available, B is established and had already taken most of what was on offer.

Account B stopped at 45/50 rather than filling the quota, on `Round produced no points, stopping instead of searching pointlessly`. That is the existing guard doing its job.

## 4. Docker

Runs the bot without installing Edge, a driver or Python on the host.

```sh
docker compose run --rm rewards-farmer
```

The image carries only what `main.py` actually reaches, selenium and numpy. `pygetwindow`, `keyboard`, `matplotlib` and `pygame` are used solely by the recording and visualisation scripts, and two of those are Windows-only. `msedgedriver` is pinned at build time to the Edge the image installed, rather than to latest, which drifts from it between releases.

`QUERY_SOURCE` defaults to `trends` in the image, so a container needs no Ollama account and no model at all.

That default exposed a real bug: `queries.py` imported `llm_utils` at module scope, which imports `ollama`, so a trends-only install still needed the ollama package. The import now happens inside the llm branch. A minimal image is good at finding that sort of thing.

`REWARDS_HEADLESS=1` drives the headless flags, and the window size is set explicitly because the pointer code works in viewport coordinates and a small headless window puts cards out of reach, which is the `MoveTargetOutOfBoundsException` from #19.

**The visual search image is bind mounted, not built in.** `visual_search.jpg` is covered by `*.jpg` in `.gitignore`, so it is in no clone and cannot be `COPY`ed at build time; without a mount the container has nothing at the path `rewards_tasks.py` uploads. The compose file mounts it read only from the project root, which is where `src/random_image_for_visual_search.py` writes it. Generating it inside the container instead would mean adding `requests` and `pillow` to an image that otherwise carries only what a run reaches, so the README directs you to run the helper once on the host. Happy to swap that round if you would rather the container were self sufficient.

### Handing a sign-in to the container

The profile has to be signed in by a browser the container can agree with about how cookies are encrypted.

**A Linux host works.** Chromium falls back to a fixed key when no keyring is running, which is the case both on a plain Linux host and inside the image, so the volume carries a working sign-in straight in. Confirmed: a profile signed in on the host opened in the container already on `rewards.bing.com/dashboard`, and both accounts above earned from it.

**A Windows host does not.** There the cookie key is wrapped with DPAPI and tied to the Windows account that wrote it, and the container has no DPAPI to unwrap it with. A profile signed in on Windows reported 73 cookies on disk, of which Edge in the container could read 19 — the ones it had just set itself — while `.MSA.Auth` and `ANON` came back absent. The container starts, looks healthy and behaves as though it were logged out.

One practical note either way: close the browser normally after signing in. A profile whose browser was killed keeps a `SingletonLock` naming the machine that wrote it, and the container reads that as the profile being open elsewhere and exits during startup.

## Also carried over from #35

The startup failure when the profile is already open. Chromium allows one process per user data directory, so the driver's copy exits and selenium reports `Chrome instance exited. Examine ChromeDriver verbose log`, which names neither the profile nor the other window and points a bot that drives Edge at a ChromeDriver log. It now names the profile and the likely cause. The wording is not stable, the same cause also produced `Microsoft Edge failed to start: crashed`, so it keys on the exception type. The lockfile is **not** a usable signal: it survives a forced kill and clears on a clean exit, so this reports the likely cause rather than claiming a detection it cannot make.

---

## Testing

`tests/test_multi_account.py` follows the convention #50 introduced: stdlib `unittest`, no new dependency, found by `python -m unittest discover -s tests`. 31 tests pass. The one case that needs a browser starts Edge twice and is behind `REWARDS_BROWSER_TESTS=1`, since discovery passes no arguments.

What it covers: which accounts a configuration produces, including 26 names that have to be refused; the flags each account hands Edge; the run loop's ordering and exit codes; one account failing in seven different ways without ending the batch; and two real profiles holding two independent identities that each survive a restart.

That last one keys on bing.com's own `MUID` rather than a cookie injected through webdriver, because an injected cookie is not written to the profile the way a `Set-Cookie` is and would prove nothing about a sign-in outliving the browser.

Beyond the suite: the two-account run in section 3, run end to end against live accounts; the query sources checked with and without network from inside the container; and in the built image, Edge 151.0.4129.107 with a driver of exactly the same build.

**One account failing used to end the batch.** Only "profile already open" was handled by name. A driver that would not start for any other reason, a first page that never loaded, or the browser dying mid-run propagated out of `run_account` and took the remaining accounts with it. `main()` now catches per account; `KeyboardInterrupt` is deliberately still not caught, since Ctrl-C should mean stop. The seven cases in the suite each assert that the other accounts still run and that every browser that started was closed, because one left running holds its profile lock against the next run.

## Merged with main

Brought up to date with `main` after #50. No conflicts. Earlier, after the random image downloader landed, there was one conflict in `.gitignore` where both sides appended a line after `*.txt` — `*.log` from the logging change here and `visual_search.json` from the downloader. Both kept.

## Splitting

Happy to split this back apart if you would rather take the pieces separately. It is one branch because #31, #35 and the multi-account work all rewrite `main.py`, and sequencing three conflicting diffs seemed worse than one review.
