### PR TITLE
wait for the daily set panel to fill, and give the breakdown time to render

### DIFF
--- a/src/rewards_tasks.py
+++ b/src/rewards_tasks.py
@@ -58,24 +58,39 @@ class RewardsTaskUtils:
 		elem = self.wait_for_element(element_getter, timeout)
 		self.move_to_and_click(elem)
 
-	def complete_bing_daily_set(self):
+	def complete_bing_daily_set(self, expected_activities: int = 3):
 		self.switch_to_earn_page()
 
 		self.wait_for_then_click(self.elements.get_open_daily_set_button)
 
-		daily_set_links = self.wait_for_element(self.elements.get_daily_set_elements)
+		# The panel hydrates progressively, so the first non-empty snapshot can
+		# hold fewer than 3 activities. wait_for_element returns on the first
+		# truthy result, so a 1-element list satisfied it and indexing [1] and
+		# [2] then raised IndexError, taking the whole task down. Wait for the
+		# full set instead, and if it never fills, work with what is there.
+		def full_activity_list():
+			activities = self.elements.get_daily_set_elements()
 
-		self.move_to_and_click(daily_set_links[0])
-		time.sleep(random.uniform(2, 3))
-		self.driver.switch_to.window(self.driver.current_window_handle) # refocus on the main tab
+			return activities if len(activities) >= expected_activities else False
 
-		self.move_to_and_click(daily_set_links[1])
-		time.sleep(random.uniform(2, 3))
-		self.driver.switch_to.window(self.driver.current_window_handle)
+		try:
+			daily_set_links = self.wait_for_element(full_activity_list, timeout=30)
+		except TimeoutException:
+			daily_set_links = self.elements.get_daily_set_elements()
 
-		self.move_to_and_click(daily_set_links[2])
-		time.sleep(random.uniform(2, 3))
-		self.driver.switch_to.window(self.driver.current_window_handle)
+			print(f"[WARNING] Daily set panel only shows {len(daily_set_links)} of {expected_activities} activities")
+
+		# Re-read the panel per index: clicking an activity can re-render it and
+		# stale the captured references.
+		for index in range(len(daily_set_links)):
+			activities = self.elements.get_daily_set_elements()
+
+			if index >= len(activities):
+				break
+
+			self.move_to_and_click(activities[index])
+			time.sleep(random.uniform(2, 3))
+			self.driver.switch_to.window(self.driver.current_window_handle) # refocus on the main tab
 
 		self.tab_utils.close_all_other_tabs()
 
@@ -198,9 +213,14 @@ class RewardsTaskUtils:
 	def read_search_points(self):
 		"""Open the points breakdown, read the Bing search row, close it again."""
 		self.switch_to_earn_page()
-		self.wait_for_then_click(self.elements.get_points_breakdown_button)
 
-		close_btn = self.wait_for_element(self.elements.get_close_button_on_points_breakdown)
+		# 30s rather than the default 10s: this runs after the earlier tasks have
+		# navigated away, so the earn page re-renders from scratch first and the
+		# breakdown button regularly needs longer than 10s to appear. Timing out
+		# here skipped the entire search task while points were still available.
+		self.wait_for_then_click(self.elements.get_points_breakdown_button, timeout=30)
+
+		close_btn = self.wait_for_element(self.elements.get_close_button_on_points_breakdown, timeout=15)
 
 		points_earned, max_pts = self.elements.get_points_earned_from_searches_on_points_breakdown()
 


### PR DESCRIPTION
Two hydration races found by running the bot on a schedule against a live account. Same family as #33, which fixes the diagnostic script waiting on a container instead of its content. These two are in the bot itself.

## 1. The daily set crashes when the panel is half rendered

`complete_bing_daily_set` indexed `[0]`, `[1]` and `[2]` on whatever `wait_for_element` returned first. That helper returns on the first truthy result, and the panel hydrates progressively, so a single-activity list satisfies it. Indexing past the end then took the whole task down before the other two activities were ever clicked:

```
[FAIL] Bing daily set: IndexError: list index out of range
```

That was a scheduled run this morning on a fresh daily set, so all three activities plus the streak were lost.

Now it waits for the full set, falls back to whatever is present if it never fills, and re-reads the panel per index because clicking an activity can re-render it and stale the captured references. When it does fall back it says so instead of silently doing less:

```
[WARNING] Daily set panel only shows 1 of 3 activities
```

## 2. The search task times out before the breakdown appears

`read_search_points` used the default 10s. It runs after the earlier tasks have navigated away, so the earn page re-renders from scratch first and the breakdown button regularly needs longer. The result was the entire search task being skipped while points were still on the table:

```
bing search 3/60 -> 57 offen
...
[SKIP] Required searches: not available in this UI variant (TimeoutException)
```

Two separate scheduled runs hit this, at 09:46 and 13:54, with 57 and 39 points available. 30s for the button, 15s for the panel.

The `[SKIP] ... not available in this UI variant` wording being wrong for a timeout is a separate problem, and mine. It is worth fixing on top of #31 once that lands, rather than in this PR.

## Verification

Ran `complete_bing_daily_set` against a freshly reset daily set, which is exactly the state that produced the IndexError:

```
before:  Daily Set Streak | Day 2 of 7 streak completed. | Activity: 0/3
after:   Daily Set Streak | Day 3 of 7 streak completed. | Activity: 3/3
```

Three activities completed, no exception, streak advanced.

Touches only `rewards_tasks.py`. It does not overlap #33, which is `check_selectors.py` only. It will conflict textually with #31 near `read_search_points`, since that converts the prints in the same region, but the two changes are independent and resolve trivially in either order.
