### PR TITLE
read the search row before waiting on the panel's close button

### DIFF
--- a/src/rewards_tasks.py
+++ b/src/rewards_tasks.py
@@ -214,12 +214,18 @@ class RewardsTaskUtils:
 		# here skipped the entire search task while points were still available.
 		self.wait_for_then_click(self.elements.get_points_breakdown_button, timeout=30)
 
-		close_btn = self.wait_for_element(self.elements.get_close_button_on_points_breakdown, timeout=15)
+		# Wait for the search row, not for the panel's close button. The close
+		# button is incidental to reading the number, and waiting on it first
+		# meant a panel that rendered its content but not its button killed the
+		# whole search task while the number was already on screen.
+		points_earned, max_pts = self.wait_for_element(
+			self.elements.get_points_earned_from_searches_on_points_breakdown,
+			timeout=30
+		)
 
-		points_earned, max_pts = self.elements.get_points_earned_from_searches_on_points_breakdown()
-
+		# Closing is best effort, the panel does not block the next navigation.
 		try:
-			self.move_to_and_click(close_btn)
+			self.move_to_and_click(self.elements.get_generic_sidebar_close_button())
 		except Exception:
 			pass
 


### PR DESCRIPTION
`read_search_points` waits for the panel's close button before it reads anything, so when the panel renders its content but not that button the whole search task dies while the number is already sitting there

Found it with a stacktrace after a scheduled run kept reporting `[SKIP] Required searches` with 45 points still open. Same call before and after on the same account

```
before   TimeoutException after 44.0s at get_close_button_on_points_breakdown
after    OK after 5.3s -> 60/60
```

The close button doesnt matter for reading the number so it reads the row first now and closing is best effort

Might be what #53 and #39 are running into, but I havent confirmed that from their side
