### PR TITLE
sign a profile in from inside the container, over a web page

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+data-dir/
+venv/
+.venv/
+__pycache__/
+**/__pycache__/
+*.pyc
+.git/
+.gitignore
+.vscode/
+*.log
+*.png
+*.jpg
+poetry.lock
+README.md
+docs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.png
 *.txt
+*.log
 !nouns.txt
 Todo.md
 data-dir/

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,20 @@ RUN EDGE_VERSION="$(microsoft-edge --version | awk '{print $3}')" \
 	&& rm /tmp/edgedriver.zip \
 	&& msedgedriver --version
 
+# Signing in needs a browser window, and the profile has to be written by the
+# container's own Edge: Chromium takes the cookie key from the operating system,
+# and on a Windows or macOS host that key is wrapped with DPAPI or the login
+# Keychain, neither of which the container can unwrap. Xvfb gives that browser a
+# display and noVNC puts it on the user's screen with nothing installed on the
+# host. Only src/signin.py reaches any of this; a run never does.
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		xvfb x11vnc novnc websockify \
+	&& rm -rf /var/lib/apt/lists/* \
+	# Debian ships vnc.html and no index.html, so a bare localhost:6080 is a 404
+	# that reads as the feature being broken.
+	&& ln -s /usr/share/novnc/vnc.html /usr/share/novnc/index.html
+
 WORKDIR /app
 
 RUN pip install --no-cache-dir "selenium>=4.46.0,<5.0.0" "numpy"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# Runs the bot without installing Edge, a driver or Python on the host.
+#
+# The image carries only what main.py actually reaches: selenium and numpy.
+# pygetwindow, keyboard, matplotlib and pygame are used solely by the
+# recording and visualisation scripts, which are developer tools rather than
+# part of a run, and two of them are Windows-only.
+#
+# QUERY_SOURCE defaults to trends here so a container needs no Ollama account
+# and no model download. Set it to llm and point OLLAMA_HOST at a reachable
+# host to use a model instead.
+
+FROM python:3.12-slim-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Edge, from Microsoft's own repository.
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		ca-certificates curl gnupg unzip fonts-liberation \
+	&& curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
+		| gpg --dearmor -o /usr/share/keyrings/microsoft.gpg \
+	&& echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/edge stable main" \
+		> /etc/apt/sources.list.d/microsoft-edge.list \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends microsoft-edge-stable \
+	&& rm -rf /var/lib/apt/lists/*
+
+# The driver has to match the browser build, so it is pinned to whatever Edge
+# the layer above installed rather than to "latest", which drifts apart from it
+# between releases.
+RUN EDGE_VERSION="$(microsoft-edge --version | awk '{print $3}')" \
+	&& curl -fsSL -o /tmp/edgedriver.zip \
+		"https://msedgedriver.microsoft.com/${EDGE_VERSION}/edgedriver_linux64.zip" \
+	&& unzip -j /tmp/edgedriver.zip msedgedriver -d /usr/local/bin \
+	&& chmod +x /usr/local/bin/msedgedriver \
+	&& rm /tmp/edgedriver.zip \
+	&& msedgedriver --version
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir "selenium>=4.46.0,<5.0.0" "numpy"
+
+COPY src/ ./src/
+COPY nouns.txt ./
+
+# Headless because there is no display, and trends because there is no model.
+ENV REWARDS_HEADLESS=1 \
+	QUERY_SOURCE=trends \
+	PYTHONUNBUFFERED=1
+
+# Sign-in lives here, so it has to outlive the container.
+VOLUME ["/app/data-dir"]
+
+CMD ["python", "src/main.py"]

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The container defaults to `QUERY_SOURCE=trends`, so it needs no Ollama account a
 docker compose run --rm --service-ports signin
 ```
 
-Open <http://localhost:6080>, sign in, then close the Edge window on that screen. The container exits on its own and the profile is ready. Nothing is installed on the host: any browser will do, on Windows, macOS or Linux.
+Open <http://localhost:6080>, sign in, then close the Edge window on that screen. The container exits on its own and the profile is ready. Nothing is installed on the host, and the host operating system stops mattering, because the profile is written inside the container rather than on the host. The screen is an ordinary web page, so whatever browser you already have will do.
 
 `--service-ports` is not optional. `docker compose run` publishes no ports without it, and the page then never loads.
 
@@ -110,6 +110,8 @@ REWARDS_ACCOUNTS=personal docker compose run --rm --service-ports signin
 ```
 
 The port is published on `127.0.0.1` only, so it is not reachable from the network. While the service is up it is showing a live Microsoft sign-in page.
+
+Signing in signs the browser in, not just the website, so Edge may sync bookmarks and autofill into the profile it just created. `data-dir` is a bot profile living in the project directory rather than your everyday browser profile, and it is gitignored, but it is worth knowing what ends up there.
 
 <details>
 <summary>Why sign-in has to happen inside the container</summary>

--- a/README.md
+++ b/README.md
@@ -93,25 +93,38 @@ docker compose run --rm rewards-farmer
 
 The container defaults to `QUERY_SOURCE=trends`, so it needs no Ollama account and no model. Set `QUERY_SOURCE=llm` and `OLLAMA_HOST` to a reachable address to use a model instead.
 
-**Sign in first.** The profile in `data-dir` starts logged out and the container has no display to sign in with, so do it once on the host with a normal Edge window and let the volume carry it in:
-
-```
-msedge --user-data-dir="<repo>\data-dir" --profile-directory=Default https://rewards.bing.com
-```
-
-Close every window of that profile afterwards, and close them normally rather than killing the browser. Chromium allows one process per profile directory, so a window left open on the host stops the container from starting. A profile whose browser was killed is worse: it keeps a `SingletonLock` naming the machine that wrote it, the container reads that as the profile being open somewhere else, and it exits during startup with the same error a genuinely open window produces.
-
-**This does not work from a Windows host.** Chromium encrypts cookie values with a key held by the operating system, and on Windows that key is wrapped with DPAPI and tied to the Windows account that wrote it. The Linux container has no DPAPI, so it cannot unwrap the key and every cookie in the profile is unreadable to it. The volume carries the file in and the browser then ignores its contents: a profile signed in on the host reported 73 cookies on disk, of which Edge in the container could read 19 — the ones it had just set itself — while `.MSA.Auth` and `ANON`, the cookies the sign-in actually rests on, came back absent. The container starts, looks healthy and behaves as though it were logged out.
-
-Sign-in has to happen wherever the container will read it, so on a Windows host run the bot directly instead:
+**Sign in first.** The profile in `data-dir` starts logged out. Sign in from inside the container, which opens the Rewards page in a browser there and puts that browser on your screen as a web page:
 
 ```sh
-python src/main.py
+docker compose run --rm --service-ports signin
 ```
 
-**A Linux host does work.** With no keyring running Chromium falls back to a fixed key, which is the case both on a plain Linux host and inside the image, so the volume carries a working sign-in straight in. Measured: a profile signed in on the host opened in the container already on `rewards.bing.com/dashboard` and earned from it.
+Open <http://localhost:6080>, sign in, then close the Edge window on that screen. The container exits on its own and the profile is ready. Nothing is installed on the host: any browser will do, on Windows, macOS or Linux.
 
-macOS is expected to fail the way Windows does, since it wraps the key with the login Keychain and the container cannot reach that either, but that case was not tested.
+`--service-ports` is not optional. `docker compose run` publishes no ports without it, and the page then never loads.
+
+One account at a time, since it is one browser window:
+
+```sh
+REWARDS_ACCOUNTS=personal docker compose run --rm --service-ports signin
+```
+
+The port is published on `127.0.0.1` only, so it is not reachable from the network. While the service is up it is showing a live Microsoft sign-in page.
+
+<details>
+<summary>Why sign-in has to happen inside the container</summary>
+
+Chromium encrypts cookie values with a key it gets from the operating system, and the container has to be able to unwrap that key to read the profile.
+
+On **Linux** with no keyring running it falls back to a fixed key, which is true both on a plain Linux host and inside the image, so a profile signed in on such a host does carry straight in.
+
+On **Windows** the key is wrapped with DPAPI and tied to the Windows account that wrote it, and the container has no DPAPI. A profile signed in with a normal Windows Edge window reported 73 cookies on disk, of which Edge in the container could read 19 — the ones it had just set itself — while `.MSA.Auth` and `ANON`, the ones the sign-in actually rests on, came back absent. The container starts, looks healthy and behaves as though it were logged out. **macOS** wraps the key with the login Keychain, which the container cannot reach either.
+
+Signing in through the container sidesteps all of this: the profile is written by the same Edge that later reads it, so the two never disagree about the key.
+
+</details>
+
+You can still sign in with a host browser if you prefer, and on a Linux host it works. Close every window of that profile afterwards, and close them rather than killing them: Chromium allows one process per profile directory, and a browser that was killed leaves a `SingletonLock` naming the machine that wrote it, which the container reads as the profile being open somewhere else.
 
 **Provide the visual search image on the host too.** `visual_search.jpg` is not in the repository and is not built into the image, so create it once in the project root and the compose file mounts it in:
 
@@ -121,9 +134,12 @@ python src/random_image_for_visual_search.py
 
 Without it every other task still runs; only the visual search one fails.
 
-Multiple accounts work the same way in the container:
+Multiple accounts work the same way in the container. Sign each profile in once, one at a time, then run them together:
 
 ```sh
+REWARDS_ACCOUNTS=personal docker compose run --rm --service-ports signin
+REWARDS_ACCOUNTS=spare    docker compose run --rm --service-ports signin
+
 REWARDS_ACCOUNTS=personal,spare docker compose run --rm rewards-farmer
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,4 +48,25 @@ EU Users: you may have to accept a consent banner once on `rewards.bing.com` and
 
 Close all webdriver browser instances. Run `main.py` again; the automation should start working.
 
+# Logging
+
+The script logs to the console. Two optional environment variables change that:
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `REWARDS_FARMER_LOG_LEVEL` | `INFO` | Set to `DEBUG` to also attach the full stack trace to every `[FAIL]` line. |
+| `REWARDS_FARMER_LOG_FILE` | unset | Path to also write the log to, useful for unattended runs. |
+
+Windows (PowerShell)
+```sh
+$env:REWARDS_FARMER_LOG_LEVEL="DEBUG"; $env:REWARDS_FARMER_LOG_FILE="run.log"; python src/main.py
+```
+
+*nix (Bash)
+```sh
+REWARDS_FARMER_LOG_LEVEL=DEBUG REWARDS_FARMER_LOG_FILE=run.log python src/main.py
+```
+
+If you are opening an issue about a crash, running with `REWARDS_FARMER_LOG_LEVEL=DEBUG` and attaching the log is the most useful thing you can include.
+
 Please open up a GitHub issue if you run into any difficulties.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Each is signed in once by hand, the same way as the single profile, using its ow
 msedge --user-data-dir="<repo>\data-dir\personal" --profile-directory=Default https://rewards.bing.com
 ```
 
-They run one after another, and a profile that fails to start is reported and skipped rather than ending the run. Leave `REWARDS_ACCOUNTS` unset and everything behaves exactly as before, using the single profile in `data-dir`.
+They run one after another, and an account that fails is reported and skipped rather than ending the run, whether it fails to start or dies partway through. Leave `REWARDS_ACCOUNTS` unset and everything behaves exactly as before, using the single profile in `data-dir`.
 
 # Docker
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ msedge --user-data-dir="<repo>\data-dir" --profile-directory=Default https://rew
 
 Close every window of that profile afterwards. Chromium allows one process per profile directory, so a window left open on the host stops the container from starting.
 
+**This does not work from a Windows host.** Chromium encrypts cookie values with a key held by the operating system, and on Windows that key is wrapped with DPAPI and tied to the Windows account that wrote it. The Linux container has no DPAPI, so it cannot unwrap the key and every cookie in the profile is unreadable to it. The volume carries the file in and the browser then ignores its contents: a profile signed in on the host reported 73 cookies on disk, of which Edge in the container could read 19 — the ones it had just set itself — while `.MSA.Auth` and `ANON`, the cookies the sign-in actually rests on, came back absent. The container starts, looks healthy and behaves as though it were logged out.
+
+Sign-in has to happen wherever the container will read it, so on a Windows host run the bot directly instead:
+
+```sh
+python src/main.py
+```
+
+Only the Windows case is measured here. A Linux host is expected to work, since the container falls back to the same scheme when no keyring is present, and macOS is expected to fail the same way for the same reason as Windows — it wraps the key with the login Keychain, which the container also cannot reach. Neither was tested.
+
 **Provide the visual search image on the host too.** `visual_search.jpg` is not in the repository and is not built into the image, so create it once in the project root and the compose file mounts it in:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ cd rewards-farmer
 # Edit the included nouns.txt file to add or replace words as needed
 ```
 
+# Where search queries come from
+
+The bot needs short strings to type into Bing. Two backends produce them, set with `QUERY_SOURCE`:
+
+| `QUERY_SOURCE` | Needs | Notes |
+| --- | --- | --- |
+| `llm` (default) | Ollama account + model | Current behaviour, unchanged |
+| `trends` | nothing | Google Trends, Wikipedia and Bing autosuggest |
+
+```sh
+QUERY_SOURCE=trends python src/main.py          # bash
+$env:QUERY_SOURCE="trends"; python src/main.py  # PowerShell
+```
+
+`trends` needs no account, no API key and no model download, so the Ollama setup below is optional if you use it. If every feed is unreachable it falls back to `nouns.txt` rather than failing the run.
+
 You should also have an Ollama account created (for the LLM), the `ollama` tool installed, and you should have signed in to the Ollama CLI via the command line using `ollama signin`. This project will use a minimal amount of Ollama cloud usage using `gemma4:cloud`. If you wish to use a different model, please change the `model` parameter in the `get_ollama_response` function in `src/llm_utils.py`.
 
 You must also provide an image for the script to upload to complete the visual search task. Currently, this image is named `keypress_times.png` and is located in the root directory of the project (yes, I used a random image from my keyboard analysis to do this). You may provide an image of your own, just ensure that the absolute path of the image is placed in the `VISUAL_SEARCH_IMAGE_PATH` constant at the top of `rewards_tasks.py`.

--- a/README.md
+++ b/README.md
@@ -66,4 +66,47 @@ EU Users: you may have to accept a consent banner once on `rewards.bing.com` and
 
 Close all webdriver browser instances. Run `main.py` again; the automation should start working.
 
+# Running more than one account
+
+Rewards is per Microsoft account and the browser profile holds the sign-in, so an account here is a profile directory. `REWARDS_ACCOUNTS` takes a comma separated list, and each name gets its own directory under `data-dir`:
+
+```sh
+REWARDS_ACCOUNTS=personal,spare python src/main.py
+```
+
+Each is signed in once by hand, the same way as the single profile, using its own directory:
+
+```
+msedge --user-data-dir="<repo>\data-dir\personal" --profile-directory=Default https://rewards.bing.com
+```
+
+They run one after another, and a profile that fails to start is reported and skipped rather than ending the run. Leave `REWARDS_ACCOUNTS` unset and everything behaves exactly as before, using the single profile in `data-dir`.
+
+# Docker
+
+Runs the bot without installing Edge, a driver or Python on the host.
+
+```sh
+docker compose build
+docker compose run --rm rewards-farmer
+```
+
+The container defaults to `QUERY_SOURCE=trends`, so it needs no Ollama account and no model. Set `QUERY_SOURCE=llm` and `OLLAMA_HOST` to a reachable address to use a model instead.
+
+**Sign in first.** The profile in `data-dir` starts logged out and the container has no display to sign in with, so do it once on the host with a normal Edge window and let the volume carry it in:
+
+```
+msedge --user-data-dir="<repo>\data-dir" --profile-directory=Default https://rewards.bing.com
+```
+
+Close every window of that profile afterwards. Chromium allows one process per profile directory, so a window left open on the host stops the container from starting.
+
+Multiple accounts work the same way in the container:
+
+```sh
+REWARDS_ACCOUNTS=personal,spare docker compose run --rm rewards-farmer
+```
+
+`REWARDS_HEADLESS=1` is set in the image. It also works on the host if you want a run with no visible window; the pointer code needs an explicit window size in that mode, which `main.py` sets.
+
 Please open up a GitHub issue if you run into any difficulties.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The container defaults to `QUERY_SOURCE=trends`, so it needs no Ollama account a
 msedge --user-data-dir="<repo>\data-dir" --profile-directory=Default https://rewards.bing.com
 ```
 
-Close every window of that profile afterwards. Chromium allows one process per profile directory, so a window left open on the host stops the container from starting.
+Close every window of that profile afterwards, and close them normally rather than killing the browser. Chromium allows one process per profile directory, so a window left open on the host stops the container from starting. A profile whose browser was killed is worse: it keeps a `SingletonLock` naming the machine that wrote it, the container reads that as the profile being open somewhere else, and it exits during startup with the same error a genuinely open window produces.
 
 **This does not work from a Windows host.** Chromium encrypts cookie values with a key held by the operating system, and on Windows that key is wrapped with DPAPI and tied to the Windows account that wrote it. The Linux container has no DPAPI, so it cannot unwrap the key and every cookie in the profile is unreadable to it. The volume carries the file in and the browser then ignores its contents: a profile signed in on the host reported 73 cookies on disk, of which Edge in the container could read 19 — the ones it had just set itself — while `.MSA.Auth` and `ANON`, the cookies the sign-in actually rests on, came back absent. The container starts, looks healthy and behaves as though it were logged out.
 
@@ -109,7 +109,9 @@ Sign-in has to happen wherever the container will read it, so on a Windows host 
 python src/main.py
 ```
 
-Only the Windows case is measured here. A Linux host is expected to work, since the container falls back to the same scheme when no keyring is present, and macOS is expected to fail the same way for the same reason as Windows — it wraps the key with the login Keychain, which the container also cannot reach. Neither was tested.
+**A Linux host does work.** With no keyring running Chromium falls back to a fixed key, which is the case both on a plain Linux host and inside the image, so the volume carries a working sign-in straight in. Measured: a profile signed in on the host opened in the container already on `rewards.bing.com/dashboard` and earned from it.
+
+macOS is expected to fail the way Windows does, since it wraps the key with the login Keychain and the container cannot reach that either, but that case was not tested.
 
 **Provide the visual search image on the host too.** `visual_search.jpg` is not in the repository and is not built into the image, so create it once in the project root and the compose file mounts it in:
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ msedge --user-data-dir="<repo>\data-dir" --profile-directory=Default https://rew
 
 Close every window of that profile afterwards. Chromium allows one process per profile directory, so a window left open on the host stops the container from starting.
 
+**Provide the visual search image on the host too.** `visual_search.jpg` is not in the repository and is not built into the image, so create it once in the project root and the compose file mounts it in:
+
+```sh
+python src/random_image_for_visual_search.py
+```
+
+Without it every other task still runs; only the visual search one fails.
+
 Multiple accounts work the same way in the container:
 
 ```sh
@@ -108,6 +116,7 @@ REWARDS_ACCOUNTS=personal,spare docker compose run --rm rewards-farmer
 ```
 
 `REWARDS_HEADLESS=1` is set in the image. It also works on the host if you want a run with no visible window; the pointer code needs an explicit window size in that mode, which `main.py` sets.
+
 # Logging
 
 The script logs to the console. Two optional environment variables change that:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
-# docker compose run --rm rewards-farmer
+# Sign a profile in once, then run against it:
 #
-# Sign-in has to happen once by hand before this is useful: the profile in
-# data-dir starts logged out. See the Docker section of the README.
+#   docker compose run --rm --service-ports signin
+#   docker compose run --rm rewards-farmer
+#
+# See the Docker section of the README.
 
 services:
   rewards-farmer:
@@ -32,3 +34,34 @@ services:
       # `python src/random_image_for_visual_search.py`; a path that does not
       # exist yet is mounted as an empty directory rather than a file.
       - ./visual_search.jpg:/app/visual_search.jpg:ro
+
+  # One off, before the first run. Opens the Rewards sign-in in a browser
+  # inside the container and puts that browser on your screen as a web page,
+  # so the profile is written by the same Edge that will later read it.
+  #
+  #   docker compose run --rm --service-ports signin
+  #   REWARDS_ACCOUNTS=personal docker compose run --rm --service-ports signin
+  #
+  # --service-ports is not optional: `run` publishes nothing without it, and
+  # the page then never loads, which reads as a broken feature rather than a
+  # missing flag.
+  #
+  # This exists because Chromium takes its cookie key from the operating
+  # system. Signed in on a Windows or macOS host that key is wrapped with
+  # DPAPI or the login Keychain, and the container can unwrap neither, so the
+  # profile arrives looking healthy and behaving as though it were logged out.
+  signin:
+    build: .
+    image: rewards-farmer
+    shm_size: 1gb
+    command: ["python", "src/signin.py"]
+    environment:
+      # One name. Signing in is one browser window, so one account at a time.
+      REWARDS_ACCOUNTS: ${REWARDS_ACCOUNTS:-}
+    ports:
+      # 127.0.0.1 is the security boundary, not decoration: for as long as this
+      # is up the port shows a live Microsoft sign-in page. Publishing it on
+      # 0.0.0.0 would offer that to the whole network.
+      - "127.0.0.1:6080:6080"
+    volumes:
+      - ./data-dir:/app/data-dir

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+# docker compose run --rm rewards-farmer
+#
+# Sign-in has to happen once by hand before this is useful: the profile in
+# data-dir starts logged out. See the Docker section of the README.
+
+services:
+  rewards-farmer:
+    build: .
+    image: rewards-farmer
+    # Chromium wants more than the default 64MB of shared memory and crashes
+    # partway through a page without it.
+    shm_size: 1gb
+    environment:
+      # trends needs no account or model, which is why it is the default here.
+      # To use a model instead, set QUERY_SOURCE=llm and give OLLAMA_HOST an
+      # address the container can reach: localhost inside a container is the
+      # container, so ollama running on the host is host.docker.internal, and
+      # 0.0.0.0 is a bind address that cannot be dialled at all.
+      #
+      #   QUERY_SOURCE=llm OLLAMA_HOST=host.docker.internal:11434 docker compose run --rm rewards-farmer
+      QUERY_SOURCE: ${QUERY_SOURCE:-trends}
+      REWARDS_HEADLESS: "1"
+      # Comma separated, one profile directory each. Leave unset for a single
+      # profile in data-dir, which is the existing behaviour.
+      REWARDS_ACCOUNTS: ${REWARDS_ACCOUNTS:-}
+      OLLAMA_HOST: ${OLLAMA_HOST:-}
+    volumes:
+      # Keeps the sign-in across container rebuilds.
+      - ./data-dir:/app/data-dir

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,3 +27,8 @@ services:
     volumes:
       # Keeps the sign-in across container rebuilds.
       - ./data-dir:/app/data-dir
+      # The visual search task uploads this file, which is gitignored and so is
+      # never in the image. Create it first with
+      # `python src/random_image_for_visual_search.py`; a path that does not
+      # exist yet is mounted as an empty directory rather than a file.
+      - ./visual_search.jpg:/app/visual_search.jpg:ro

--- a/src/accounts.py
+++ b/src/accounts.py
@@ -1,0 +1,85 @@
+"""Which accounts a run works through.
+
+Rewards is per Microsoft account, and the browser profile is what holds the
+sign-in, so an account here is just a profile directory. One directory per
+account keeps their cookies apart, which is the whole requirement.
+
+    REWARDS_ACCOUNTS=personal,spare python src/main.py
+
+Unset, the run uses the single profile in constants.py exactly as before, so
+nothing about an existing setup changes.
+"""
+
+import os
+import re
+from dataclasses import dataclass
+
+from constants import USER_DATA_DIR, PROFILE_NAME
+
+ENV_VAR = "REWARDS_ACCOUNTS"
+
+# Names become directory names, so keep them to something a filesystem and a
+# command line both handle without quoting.
+SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+@dataclass(frozen=True)
+class Account:
+	"""A named browser profile to run the tasks against."""
+
+	name: str
+	user_data_dir: str
+	profile_name: str
+
+	@property
+	def is_default(self) -> bool:
+		return self.user_data_dir == USER_DATA_DIR
+
+
+def _named(name: str) -> Account:
+	# Each account gets its own directory under the configured one, so the
+	# existing data-dir stays where it is and the new ones sit beside the
+	# profile it already holds.
+	return Account(
+		name=name,
+		user_data_dir=os.path.join(USER_DATA_DIR, name),
+		profile_name=PROFILE_NAME,
+	)
+
+
+def configured() -> list[Account]:
+	"""Accounts for this run, in order.
+
+	Raises ValueError on a name that cannot be a directory, rather than
+	silently creating something surprising next to the real profiles.
+	"""
+	raw = os.environ.get(ENV_VAR, "").strip()
+
+	if not raw:
+		return [Account(name="default", user_data_dir=USER_DATA_DIR, profile_name=PROFILE_NAME)]
+
+	names = [part.strip() for part in raw.split(",")]
+	names = [name for name in names if name]
+
+	if not names:
+		return [Account(name="default", user_data_dir=USER_DATA_DIR, profile_name=PROFILE_NAME)]
+
+	seen: set[str] = set()
+	accounts: list[Account] = []
+
+	for name in names:
+		if not SAFE_NAME.match(name):
+			raise ValueError(
+				f"{ENV_VAR} entry {name!r} is not usable as a directory name; "
+				"use letters, digits, dot, dash or underscore"
+			)
+
+		# Duplicates would run the same profile twice, which earns nothing the
+		# second time and doubles the run length.
+		if name.lower() in seen:
+			continue
+
+		seen.add(name.lower())
+		accounts.append(_named(name))
+
+	return accounts

--- a/src/accounts.py
+++ b/src/accounts.py
@@ -19,8 +19,14 @@ from constants import USER_DATA_DIR, PROFILE_NAME
 ENV_VAR = "REWARDS_ACCOUNTS"
 
 # Names become directory names, so keep them to something a filesystem and a
-# command line both handle without quoting.
+# command line both handle without quoting. The character set alone is not
+# enough: "." and ".." are made of allowed characters and still walk out of the
+# directory, so they are rejected by name below and the resolved path is
+# checked as well.
 SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Reserved by every filesystem that has directories at all.
+RESERVED_NAMES = {".", ".."}
 
 
 @dataclass(frozen=True)
@@ -40,9 +46,22 @@ def _named(name: str) -> Account:
 	# Each account gets its own directory under the configured one, so the
 	# existing data-dir stays where it is and the new ones sit beside the
 	# profile it already holds.
+	user_data_dir = os.path.join(USER_DATA_DIR, name)
+
+	# The name passed the character check, but that only constrains the
+	# characters, not where they end up pointing. Confirm against the resolved
+	# path, which is the thing Edge is actually handed.
+	root = os.path.abspath(USER_DATA_DIR)
+	resolved = os.path.abspath(user_data_dir)
+
+	if os.path.commonpath([root, resolved]) != root or resolved == root:
+		raise ValueError(
+			f"{ENV_VAR} entry {name!r} resolves outside the profile directory"
+		)
+
 	return Account(
 		name=name,
-		user_data_dir=os.path.join(USER_DATA_DIR, name),
+		user_data_dir=user_data_dir,
 		profile_name=PROFILE_NAME,
 	)
 
@@ -68,7 +87,7 @@ def configured() -> list[Account]:
 	accounts: list[Account] = []
 
 	for name in names:
-		if not SAFE_NAME.match(name):
+		if not SAFE_NAME.match(name) or name in RESERVED_NAMES:
 			raise ValueError(
 				f"{ENV_VAR} entry {name!r} is not usable as a directory name; "
 				"use letters, digits, dot, dash or underscore"

--- a/src/accounts.py
+++ b/src/accounts.py
@@ -50,9 +50,11 @@ def _named(name: str) -> Account:
 
 	# The name passed the character check, but that only constrains the
 	# characters, not where they end up pointing. Confirm against the resolved
-	# path, which is the thing Edge is actually handed.
-	root = os.path.abspath(USER_DATA_DIR)
-	resolved = os.path.abspath(user_data_dir)
+	# path, which is the thing Edge is actually handed. realpath rather than
+	# abspath, so a link or a junction under the profile directory is followed
+	# to where it really goes instead of being taken at face value.
+	root = os.path.realpath(USER_DATA_DIR)
+	resolved = os.path.realpath(user_data_dir)
 
 	if os.path.commonpath([root, resolved]) != root or resolved == root:
 		raise ValueError(
@@ -87,10 +89,15 @@ def configured() -> list[Account]:
 	accounts: list[Account] = []
 
 	for name in names:
-		if not SAFE_NAME.match(name) or name in RESERVED_NAMES:
+		# The trailing dot is not cosmetic. Win32 strips one off a path
+		# component and python's normalisation does not, so such a name means a
+		# different directory than it reads as: "work." is "work", and "..." is
+		# the profile directory itself. Either way two entries end up sharing
+		# one profile, which is the one thing this module exists to prevent.
+		if not SAFE_NAME.match(name) or name in RESERVED_NAMES or name.endswith("."):
 			raise ValueError(
 				f"{ENV_VAR} entry {name!r} is not usable as a directory name; "
-				"use letters, digits, dot, dash or underscore"
+				"use letters, digits, dot, dash or underscore, and do not end in a dot"
 			)
 
 		# Duplicates would run the same profile twice, which earns nothing the

--- a/src/llm_utils.py
+++ b/src/llm_utils.py
@@ -1,6 +1,9 @@
 from typing import Generator
+import logging
 import random
 import ollama
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_SYSTEM_PROMPT_FOR_SEARCH_QUEST = (
 	"You are a helpful assistant tasked with creating a search query based on a directive. "
@@ -55,7 +58,7 @@ def get_nonempty_ollama_response(messages: list[dict[str, str]]) -> str:
 		if response and response.strip():
 			return response
 
-		print(f"[WARNING] Empty LLM response, retry {attempt + 1}/{MAX_EMPTY_RETRIES}")
+		logger.warning("Empty LLM response, retry %s/%s", attempt + 1, MAX_EMPTY_RETRIES)
 
 	raise RuntimeError(f"LLM returned nothing usable after {MAX_EMPTY_RETRIES} attempts")
 

--- a/src/log_utils.py
+++ b/src/log_utils.py
@@ -1,0 +1,100 @@
+"""Central logging configuration.
+
+`setup_logging` is called once from `main.py`. Every other module just does
+`logger = logging.getLogger(__name__)` at import time, which is safe to do
+before this runs, so import order does not matter.
+"""
+
+import logging
+import os
+import sys
+
+LEVEL_ENV_VAR = "REWARDS_FARMER_LOG_LEVEL"
+FILE_ENV_VAR = "REWARDS_FARMER_LOG_FILE"
+
+DEFAULT_LEVEL = "INFO"
+
+# Configuring the root logger switches on output for every library that logs,
+# not just ours. httpx emits an info line per ollama call, which buries the
+# task summary and puts the ollama endpoint in the log file. print never did
+# this because it never touched logging at all, so leaving these at their
+# default would make the output noisier than what it replaces.
+NOISY_LIBRARIES = ("httpx", "httpcore", "urllib3", "selenium")
+
+# CRITICAL is the longest level name at 8 characters, so pad to that and the
+# message column stays aligned no matter what is being logged.
+LOG_FORMAT = "%(asctime)s %(levelname)-8s %(name)s: %(message)s"
+DATE_FORMAT = "%H:%M:%S"
+
+_configured = False
+
+
+def _resolve_level(level: str | int | None) -> int:
+	"""Turn a level name, a level number or None into a level number.
+
+	An unusable value falls back to the default rather than raising. A typo in
+	an environment variable must not be able to take down an unattended run.
+	"""
+	if level is None:
+		level = os.environ.get(LEVEL_ENV_VAR, DEFAULT_LEVEL)
+
+	if isinstance(level, int):
+		return level
+
+	resolved = logging.getLevelNamesMapping().get(str(level).strip().upper())
+
+	if resolved is None:
+		logging.getLogger(__name__).warning(
+			"Unknown log level %r, falling back to %s", level, DEFAULT_LEVEL
+		)
+
+		return logging.getLevelNamesMapping()[DEFAULT_LEVEL]
+
+	return resolved
+
+
+def setup_logging(level: str | int | None = None, log_file: str | None = None) -> None:
+	"""Configure the root logger. Calling this more than once is a no-op.
+
+	`level` defaults to $REWARDS_FARMER_LOG_LEVEL, then to INFO.
+	`log_file` defaults to $REWARDS_FARMER_LOG_FILE, and no file is written
+	when neither is set.
+	"""
+	global _configured
+
+	if _configured:
+		return
+
+	root = logging.getLogger()
+	root.setLevel(_resolve_level(level))
+
+	formatter = logging.Formatter(LOG_FORMAT, datefmt=DATE_FORMAT)
+
+	# Card descriptions are scraped from the page and are not ASCII outside the
+	# en-US market, which the Windows console encoding cannot represent. Replace
+	# those characters instead of letting the write raise.
+	if hasattr(sys.stdout, "reconfigure"):
+		sys.stdout.reconfigure(errors="replace")
+
+	# stdout rather than the StreamHandler default of stderr, because this
+	# replaces print and anyone already redirecting stdout to a file should
+	# keep getting the same output there.
+	console = logging.StreamHandler(sys.stdout)
+	console.setFormatter(formatter)
+	root.addHandler(console)
+
+	if log_file is None:
+		log_file = os.environ.get(FILE_ENV_VAR)
+
+	if log_file:
+		# utf-8 explicitly. Card descriptions are scraped from the page and are
+		# not ASCII outside the en-US market, and the Windows default encoding
+		# would raise on them.
+		file_handler = logging.FileHandler(log_file, encoding="utf-8")
+		file_handler.setFormatter(formatter)
+		root.addHandler(file_handler)
+
+	for name in NOISY_LIBRARIES:
+		logging.getLogger(name).setLevel(logging.WARNING)
+
+	_configured = True

--- a/src/log_utils.py
+++ b/src/log_utils.py
@@ -7,6 +7,7 @@ before this runs, so import order does not matter.
 
 import logging
 import os
+import re
 import sys
 
 LEVEL_ENV_VAR = "REWARDS_FARMER_LOG_LEVEL"
@@ -20,6 +21,36 @@ DEFAULT_LEVEL = "INFO"
 # this because it never touched logging at all, so leaving these at their
 # default would make the output noisier than what it replaces.
 NOISY_LIBRARIES = ("httpx", "httpcore", "urllib3", "selenium")
+
+# Longest a one-line exception summary may get before it is cut. Long enough
+# for any real selenium message, short enough that a pathological one cannot
+# push a whole screen of text into a single record.
+MAX_SUMMARY_LENGTH = 300
+
+_SESSION_INFO = re.compile(r"\s*\(Session info:[^)]*\)")
+
+
+def exception_summary(exc: BaseException) -> str:
+	"""One short line describing an exception, safe to put in a log record.
+
+	str() on a selenium exception is multi-line: the message, then a session
+	info line, then the whole msedgedriver stacktrace. Only the first line is
+	worth showing in a per-task summary, and the full detail is still attached
+	as a traceback when the level is debug.
+	"""
+	text = str(exc).strip()
+
+	if not text:
+		return ""
+
+	text = _SESSION_INFO.sub("", text.splitlines()[0]).strip()
+
+	if len(text) > MAX_SUMMARY_LENGTH:
+		# ASCII, because this can land on a Windows console whose encoding
+		# cannot represent an ellipsis character.
+		text = text[:MAX_SUMMARY_LENGTH - 3].rstrip() + "..."
+
+	return text
 
 # CRITICAL is the longest level name at 8 characters, so pad to that and the
 # message column stays aligned no matter what is being logged.

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,11 @@
+import log_utils
 import rewards_tasks
 import mouse_trajectory
 import mimic_typing
 from selenium import webdriver
 from constants import USER_DATA_DIR, PROFILE_NAME
+
+log_utils.setup_logging()
 
 options = webdriver.EdgeOptions()
 

--- a/src/main.py
+++ b/src/main.py
@@ -5,8 +5,6 @@ import sys
 import log_utils
 import accounts
 import rewards_tasks
-import mouse_trajectory
-import mimic_typing
 from selenium import webdriver
 from selenium.common.exceptions import SessionNotCreatedException
 
@@ -54,9 +52,6 @@ def run_account(account: accounts.Account) -> bool:
 		return False
 
 	try:
-		mouse = mouse_trajectory.MouseUtils(driver)
-		keyboard = mimic_typing.KeyboardUtils(driver)
-
 		rewards = rewards_tasks.RewardsTaskUtils(driver)
 		rewards.complete_all_tasks()
 	finally:

--- a/src/main.py
+++ b/src/main.py
@@ -55,7 +55,16 @@ def run_account(account: accounts.Account) -> bool:
 		rewards = rewards_tasks.RewardsTaskUtils(driver)
 		rewards.complete_all_tasks()
 	finally:
-		driver.quit()
+		try:
+			driver.quit()
+		except Exception as exc:
+			# quit() raises when the browser is already gone. Letting it out
+			# here would replace whatever actually went wrong with the tidy-up's
+			# own error, and the process it is meant to end is dead anyway.
+			logger.warning(
+				"%s: the driver did not shut down cleanly: %s",
+				account.name, log_utils.exception_summary(exc)
+			)
 
 	return True
 
@@ -76,8 +85,21 @@ def main() -> int:
 		if len(configured) > 1:
 			logger.info("=== account: %s ===", account.name)
 
-		if run_account(account):
-			started += 1
+		# One account must not be able to end the batch. complete_all_tasks
+		# already contains a task that fails, and run_account names the profile
+		# that is already open, but everything else - a driver that will not
+		# start for some other reason, the browser dying mid-run, a page that
+		# never loads - reached here and took the remaining accounts with it.
+		# KeyboardInterrupt is deliberately not caught: Ctrl-C means stop.
+		try:
+			if run_account(account):
+				started += 1
+		except Exception as exc:
+			logger.error(
+				"[FAIL] %s: %s: %s",
+				account.name, type(exc).__name__, log_utils.exception_summary(exc),
+				exc_info=logger.isEnabledFor(logging.DEBUG)
+			)
 
 	if len(configured) > 1:
 		logger.info("%s/%s accounts ran", started, len(configured))

--- a/src/main.py
+++ b/src/main.py
@@ -1,26 +1,92 @@
+import os
+import sys
+
+import accounts
 import rewards_tasks
 import mouse_trajectory
 import mimic_typing
 from selenium import webdriver
-from constants import USER_DATA_DIR, PROFILE_NAME
+from selenium.common.exceptions import SessionNotCreatedException
 
-options = webdriver.EdgeOptions()
+HEADLESS = os.environ.get("REWARDS_HEADLESS", "").strip().lower() in ("1", "true", "yes")
 
-options.add_experimental_option("excludeSwitches", ["enable-automation"])
-options.add_experimental_option('useAutomationExtension', False)
-options.add_argument("--disable-blink-features=AutomationControlled")
-options.add_argument(f"--user-data-dir={USER_DATA_DIR}")
-options.add_argument(f"--profile-directory={PROFILE_NAME}")
 
-driver = webdriver.Edge(options=options)
+def build_options(account: accounts.Account) -> webdriver.EdgeOptions:
+	options = webdriver.EdgeOptions()
 
-mouse = mouse_trajectory.MouseUtils(driver)
-keyboard = mimic_typing.KeyboardUtils(driver)
+	options.add_experimental_option("excludeSwitches", ["enable-automation"])
+	options.add_experimental_option('useAutomationExtension', False)
+	options.add_argument("--disable-blink-features=AutomationControlled")
+	options.add_argument(f"--user-data-dir={account.user_data_dir}")
+	options.add_argument(f"--profile-directory={account.profile_name}")
 
-rewards = rewards_tasks.RewardsTaskUtils(driver)
+	if HEADLESS:
+		# A container has no display. The window size is set explicitly because
+		# the pointer code works in viewport coordinates, and the default
+		# headless window is small enough to put cards out of reach.
+		options.add_argument("--headless=new")
+		options.add_argument("--window-size=1920,1080")
+		options.add_argument("--no-sandbox")
+		options.add_argument("--disable-dev-shm-usage")
 
-rewards.complete_all_tasks()
+	return options
 
-input("Press Enter to exit...")
 
-driver.quit()
+def run_account(account: accounts.Account) -> bool:
+	"""Work one account. Returns whether the browser started."""
+	try:
+		driver = webdriver.Edge(options=build_options(account))
+	except SessionNotCreatedException as exc:
+		# Chromium allows one process per user data directory. When the profile
+		# is already open the driver's copy exits during startup, and selenium
+		# reports it as the browser crashing with a message that names neither
+		# the profile nor the other window.
+		print(f"[FAIL] {account.name}: could not start Edge with this profile.")
+		print(f"       profile directory: {account.user_data_dir}")
+		print("       The usual cause is that this profile is already open in another")
+		print("       Edge window, including one left over from a previous run.")
+		print(f"       driver said: {str(exc).strip().splitlines()[0]}")
+
+		return False
+
+	try:
+		mouse = mouse_trajectory.MouseUtils(driver)
+		keyboard = mimic_typing.KeyboardUtils(driver)
+
+		rewards = rewards_tasks.RewardsTaskUtils(driver)
+		rewards.complete_all_tasks()
+	finally:
+		driver.quit()
+
+	return True
+
+
+def main() -> int:
+	try:
+		configured = accounts.configured()
+	except ValueError as exc:
+		print(f"[FAIL] {exc}")
+
+		return 2
+
+	started = 0
+
+	for account in configured:
+		if len(configured) > 1:
+			print(f"\n=== account: {account.name} ===")
+
+		if run_account(account):
+			started += 1
+
+	if len(configured) > 1:
+		print(f"\n{started}/{len(configured)} accounts ran")
+
+	# Nothing is watching a container, and stdin is not a terminal there.
+	if not HEADLESS:
+		input("Press Enter to exit...")
+
+	return 0 if started else 1
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/src/queries.py
+++ b/src/queries.py
@@ -49,7 +49,7 @@ def search_query_for_task(task_description: str) -> str:
 
 		# Every feed was unreachable. The description still contains the topic,
 		# so a trimmed version beats skipping the card entirely.
-		logger.warning("No query source reachable, using the task description as written.")
+		logger.warning("No query source reachable, using the lowercased task description.")
 
 		return task_description.lower()
 

--- a/src/queries.py
+++ b/src/queries.py
@@ -13,8 +13,13 @@ Bing, and Bing's own autosuggest answers that question directly.
 
 import os
 
-import llm_utils
 import query_sources
+
+# llm_utils is imported inside the llm branch rather than here. It imports
+# ollama at module scope, so importing it eagerly would make the ollama package
+# a hard requirement even for a run that never touches a model, which is the
+# opposite of the point. A trends-only install, the Docker image for instance,
+# does not ship it.
 
 LLM = "llm"
 TRENDS = "trends"
@@ -45,6 +50,8 @@ def search_query_for_task(task_description: str) -> str:
 
 		return task_description.lower()
 
+	import llm_utils
+
 	return llm_utils.get_search_query_from_task_description(task_description)
 
 
@@ -59,6 +66,8 @@ def related_queries(count: int):
 		print("[WARNING] No query source reachable, falling back to the wordlist.")
 
 		# nouns.txt is already in the repo for exactly this kind of seed.
-		return [llm_utils.get_random_noun() for _ in range(count)]
+		return query_sources.wordlist_queries(count)
+
+	import llm_utils
 
 	return llm_utils.get_related_search_queries(llm_utils.get_random_noun(), num_queries=count)

--- a/src/queries.py
+++ b/src/queries.py
@@ -1,0 +1,64 @@
+"""Where search queries come from.
+
+Two backends. `llm` is the default and is unchanged, so nothing about an
+existing setup moves. `trends` uses public feeds and needs no account, no
+model and no key, which is the difference between running this in five
+minutes and installing Ollama first.
+
+    QUERY_SOURCE=trends python src/main.py
+
+The LLM's whole job in this project is producing short strings to type into
+Bing, and Bing's own autosuggest answers that question directly.
+"""
+
+import os
+
+import llm_utils
+import query_sources
+
+LLM = "llm"
+TRENDS = "trends"
+
+DEFAULT_SOURCE = LLM
+
+ENV_VAR = "QUERY_SOURCE"
+
+
+def selected_source() -> str:
+	"""Read on each call so a test can change it without reimporting."""
+	choice = os.environ.get(ENV_VAR, DEFAULT_SOURCE).strip().lower()
+
+	return choice if choice in (LLM, TRENDS) else DEFAULT_SOURCE
+
+
+def search_query_for_task(task_description: str) -> str:
+	"""A query for one "Search on Bing for X" card."""
+	if selected_source() == TRENDS:
+		query = query_sources.query_from_task_description(task_description)
+
+		if query:
+			return query
+
+		# Every feed was unreachable. The description still contains the topic,
+		# so a trimmed version beats skipping the card entirely.
+		print("[WARNING] No query source reachable, using the task description as written.")
+
+		return task_description.lower()
+
+	return llm_utils.get_search_query_from_task_description(task_description)
+
+
+def related_queries(count: int):
+	"""`count` queries for the daily search quota."""
+	if selected_source() == TRENDS:
+		queries = query_sources.related_queries(count)
+
+		if queries:
+			return queries
+
+		print("[WARNING] No query source reachable, falling back to the wordlist.")
+
+		# nouns.txt is already in the repo for exactly this kind of seed.
+		return [llm_utils.get_random_noun() for _ in range(count)]
+
+	return llm_utils.get_related_search_queries(llm_utils.get_random_noun(), num_queries=count)

--- a/src/query_sources.py
+++ b/src/query_sources.py
@@ -130,6 +130,24 @@ def suggestions(seed: str) -> list[str]:
 	return [_clean(s) for s in payload[1] if _clean(s)]
 
 
+def wordlist_queries(count: int) -> list[str]:
+	"""Seeds from nouns.txt, the last resort when nothing is reachable.
+
+	Read here rather than borrowed from llm_utils so that a trends-only install
+	never has to import the model client.
+	"""
+	try:
+		with open("nouns.txt", encoding="utf-8") as handle:
+			nouns = [line.strip().lower() for line in handle if len(line.strip()) >= 3]
+	except OSError:
+		return []
+
+	if not nouns:
+		return []
+
+	return random.sample(nouns, min(count, len(nouns)))
+
+
 def _clean(text: str) -> str:
 	"""Strip markup, collapse whitespace and drop punctuation Bing does not need."""
 	text = re.sub(r"<[^>]+>", " ", text or "")

--- a/src/query_sources.py
+++ b/src/query_sources.py
@@ -1,0 +1,198 @@
+"""Search queries from public feeds instead of a language model.
+
+The LLM in this project has one job: produce short strings to type into Bing.
+That is worth an Ollama account and a model download if you want it, but it is
+not the only way to get a search query, and it is the piece that stops someone
+running the bot in five minutes.
+
+Three keyless sources, all stdlib, no new dependencies:
+
+  Google Trends RSS   real queries people are typing right now
+  Wikipedia most-read topic seeds, useful when trends is unavailable
+  Bing autosuggest    expands a seed into related queries
+
+Autosuggest is what makes the chaining work. Asking Bing what follows a term
+gives queries Bing itself expects, which is closer to what the LLM prompt was
+reaching for than a model guessing in the dark.
+
+Every source degrades rather than raises. A search that does not happen costs
+points; a run that dies costs the rest of the day's points too.
+"""
+
+import json
+import random
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import date, timedelta
+
+TRENDS_URL = "https://trends.google.com/trending/rss?geo={geo}"
+WIKIPEDIA_URL = "https://en.wikipedia.org/api/rest_v1/feed/featured/{y}/{m:02d}/{d:02d}"
+AUTOSUGGEST_URL = "https://api.bing.com/osjson.aspx?query={query}"
+
+# A browser agent: trends and the Wikipedia REST feed both answer differently
+# to an unfamiliar client, and one of them refuses outright.
+USER_AGENT = (
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+	"(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+
+REQUEST_TIMEOUT = 15
+
+# Words that make a query read as an instruction rather than a search. The
+# task descriptions are phrased at the user, "Search on Bing to compare
+# checking accounts", and typing that verbatim searches for the sentence.
+INSTRUCTION_WORDS = {
+	"search", "searching", "bing", "on", "to", "the", "a", "an", "for", "your",
+	"you", "use", "using", "find", "get", "with", "and", "or", "of", "in",
+	"at", "by", "now", "today", "this", "that", "these", "those", "learn",
+	"discover", "explore", "check", "see", "our", "more", "about", "how",
+}
+
+
+def _fetch(url: str) -> str | None:
+	"""Body of a GET, or None. Never raises: callers fall through to the next source."""
+	request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+
+	try:
+		with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:
+			return response.read().decode("utf-8", "replace")
+	except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError):
+		return None
+
+
+def trending_queries(geo: str = "US") -> list[str]:
+	"""Queries currently trending on Google, most popular first.
+
+	These are real searches rather than descriptions of searches, which is
+	exactly the shape wanted here.
+	"""
+	body = _fetch(TRENDS_URL.format(geo=urllib.parse.quote(geo)))
+
+	if not body:
+		return []
+
+	# The channel carries a <title> of its own before any item, so the first
+	# match is the feed name rather than a query.
+	titles = re.findall(r"<title>(?:<!\[CDATA\[)?(.*?)(?:\]\]>)?</title>", body, re.S)
+
+	return [_clean(t) for t in titles[1:] if _clean(t)]
+
+
+def wikipedia_topics(days_ago: int = 1) -> list[str]:
+	"""Most-read Wikipedia articles, as topic seeds.
+
+	Yesterday by default: today's feed is not published until the day is over.
+	"""
+	day = date.today() - timedelta(days=days_ago)
+	body = _fetch(WIKIPEDIA_URL.format(y=day.year, m=day.month, d=day.day))
+
+	if not body:
+		return []
+
+	try:
+		payload = json.loads(body)
+	except json.JSONDecodeError:
+		return []
+
+	articles = payload.get("mostread", {}).get("articles", [])
+	titles = [a.get("titles", {}).get("normalized", "") for a in articles]
+
+	# Wikipedia's own chrome outranks real topics most days.
+	skipped = ("Main Page", "Special:", "Wikipedia:", "Portal:")
+
+	return [
+		_clean(t) for t in titles
+		if t and not t.startswith(skipped) and _clean(t)
+	]
+
+
+def suggestions(seed: str) -> list[str]:
+	"""What Bing suggests for a term, which is what Bing expects to be asked."""
+	if not seed.strip():
+		return []
+
+	body = _fetch(AUTOSUGGEST_URL.format(query=urllib.parse.quote(seed)))
+
+	if not body:
+		return []
+
+	try:
+		payload = json.loads(body)
+	except json.JSONDecodeError:
+		return []
+
+	# Opensearch shape: [term, [suggestions], ...]
+	if not isinstance(payload, list) or len(payload) < 2 or not isinstance(payload[1], list):
+		return []
+
+	return [_clean(s) for s in payload[1] if _clean(s)]
+
+
+def _clean(text: str) -> str:
+	"""Strip markup, collapse whitespace and drop punctuation Bing does not need."""
+	text = re.sub(r"<[^>]+>", " ", text or "")
+	text = re.sub(r"[\"'?!,;:]", " ", text)
+
+	return " ".join(text.split()).strip().lower()
+
+
+def query_from_task_description(description: str) -> str | None:
+	"""A search query for a task phrased as an instruction.
+
+	"Search on Bing to compare checking and savings account options" becomes
+	the content words, then whatever Bing suggests for them, so the query is
+	one Bing already recognises rather than the sentence itself.
+	"""
+	words = [w for w in _clean(description).split() if w not in INSTRUCTION_WORDS]
+
+	if not words:
+		return None
+
+	seed = " ".join(words[:6])
+	options = suggestions(seed)
+
+	# Prefer a suggestion, since it is a query Bing has seen. The trimmed
+	# sentence is a reasonable fallback and still beats typing the imperative.
+	return options[0] if options else seed
+
+
+def related_queries(count: int, seed: str | None = None) -> list[str]:
+	"""`count` distinct queries, branching out the way the LLM prompt asks for.
+
+	Trending queries first, since they need no expansion at all, then Bing's
+	suggestions for each to reach the requested number.
+	"""
+	collected: list[str] = []
+	seen: set[str] = set()
+
+	def take(candidates):
+		for candidate in candidates:
+			if candidate and candidate not in seen and len(candidate) > 2:
+				seen.add(candidate)
+				collected.append(candidate)
+
+				if len(collected) >= count:
+					return True
+		return False
+
+	if seed:
+		take(suggestions(seed))
+
+	if len(collected) < count and take(trending_queries()):
+		return collected[:count]
+
+	if len(collected) < count:
+		take(wikipedia_topics())
+
+	# Expand what we have until the count is met. Iterating over a snapshot
+	# because take() appends to the same list.
+	for term in list(collected):
+		if len(collected) >= count:
+			break
+
+		take(suggestions(term))
+
+	# Nothing reachable: let the caller decide, rather than typing junk.
+	return collected[:count]

--- a/src/rewards_tasks.py
+++ b/src/rewards_tasks.py
@@ -10,7 +10,7 @@ from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.common.exceptions import StaleElementReferenceException, TimeoutException, NoSuchElementException
 import tab_utils
-import llm_utils
+import queries
 import mouse_trajectory
 import mimic_typing
 import element_selectors
@@ -93,7 +93,7 @@ class RewardsTaskUtils:
 
 		for card in explore_on_bing_links:
 			desc = self.elements.extract_card_descriptions(card)
-			query = llm_utils.get_search_query_from_task_description(desc)
+			query = queries.search_query_for_task(desc)
 
 			self.move_to_and_click(card)
 			self.tab_utils.switch_to_other_tab()
@@ -220,9 +220,7 @@ class RewardsTaskUtils:
 		# search bar should be auto-focused
 
 		for i, query in enumerate(
-			llm_utils.get_related_search_queries(
-				llm_utils.get_random_noun(), num_queries=count
-			)
+			queries.related_queries(count)
 		):
 			self.keyboard.send_keys(f"{query} -noai{Keys.ENTER}")
 

--- a/src/rewards_tasks.py
+++ b/src/rewards_tasks.py
@@ -1,4 +1,5 @@
 import logging
+import log_utils
 import os
 import random
 import time
@@ -284,12 +285,8 @@ class RewardsTaskUtils:
 			except (NoSuchElementException, TimeoutException) as exc:
 				logger.warning("[SKIP] %s: not available in this UI variant (%s)", name, type(exc).__name__)
 			except Exception as exc:
-				# A selenium exception carries the whole msedgedriver stacktrace
-				# in str(), tens of lines of it, so keep the summary to the
-				# first line and let the traceback on debug hold the rest.
-				message = str(exc).strip().splitlines()
 				logger.error(
-					"[FAIL] %s: %s: %s", name, type(exc).__name__, message[0] if message else "",
+					"[FAIL] %s: %s: %s", name, type(exc).__name__, log_utils.exception_summary(exc),
 					exc_info=logger.isEnabledFor(logging.DEBUG)
 				)
 

--- a/src/rewards_tasks.py
+++ b/src/rewards_tasks.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import random
 import time
@@ -16,6 +17,8 @@ import mimic_typing
 import element_selectors
 
 VISUAL_SEARCH_IMAGE_PATH = os.path.abspath("visual_search.jpg")
+
+logger = logging.getLogger(__name__)
 
 class RewardsTaskUtils:
 	def __init__(self, driver: webdriver.Edge):
@@ -113,7 +116,10 @@ class RewardsTaskUtils:
 
 		for card in explore_on_bing_links:
 			if not self.elements.card_is_complete(card):
-				print(f"[WARNING] Explore on Bing Card [desc={self.elements.extract_card_descriptions(card)!r}] is not complete after searching. Please check manually.")
+				logger.warning(
+					"Explore on Bing Card [desc=%r] is not complete after searching. Please check manually.",
+					self.elements.extract_card_descriptions(card)
+				)
 
 	def complete_visual_search(self):
 		self.switch_to_earn_page()
@@ -154,7 +160,10 @@ class RewardsTaskUtils:
 
 		for card in misc_cards:
 			if not self.elements.card_is_complete(card) and self.elements.get_card_point_value(card) > 0:
-				print(f"[WARNING] Misc Card [desc={self.elements.extract_card_descriptions(card)!r}] is not complete after clicking. Please check manually.")
+				logger.warning(
+					"Misc Card [desc=%r] is not complete after clicking. Please check manually.",
+					self.elements.extract_card_descriptions(card)
+				)
 
 		self.tab_utils.close_all_other_tabs()
 
@@ -170,7 +179,7 @@ class RewardsTaskUtils:
 		# Measure, search, measure again.
 		points_earned, max_pts = self.read_search_points()
 
-		print(f"[INFO] Search points before: {points_earned}/{max_pts}")
+		logger.info("Search points before: %s/%s", points_earned, max_pts)
 
 		for round_number in range(1, max_rounds + 1):
 			if points_earned >= max_pts:
@@ -184,16 +193,19 @@ class RewardsTaskUtils:
 			previous = points_earned
 			points_earned, max_pts = self.read_search_points()
 
-			print(f"[INFO] Round {round_number}: {searches} searches -> {points_earned}/{max_pts}")
+			logger.info(
+				"Round %s: %s searches -> %s/%s",
+				round_number, searches, points_earned, max_pts
+			)
 
 			if points_earned <= previous:
-				print("[WARNING] Round produced no points, stopping instead of searching pointlessly.")
+				logger.warning("Round produced no points, stopping instead of searching pointlessly.")
 				break
 
 		if points_earned < max_pts:
-			print(f"[WARNING] Search quota not filled: {points_earned}/{max_pts}")
+			logger.warning("Search quota not filled: %s/%s", points_earned, max_pts)
 		else:
-			print(f"Search quota complete: {points_earned}/{max_pts}")
+			logger.info("Search quota complete: %s/%s", points_earned, max_pts)
 
 	def read_search_points(self):
 		"""Open the points breakdown, read the Bing search row, close it again."""
@@ -230,7 +242,10 @@ class RewardsTaskUtils:
 
 			try: self.wait_for_then_click(self.elements.get_clear_bing_search_query_button)
 			except StaleElementReferenceException:
-				print(f"[WARNING] StaleElementReferenceException when trying to click the clear button for query {i+1}. Trying again...")
+				logger.warning(
+					"StaleElementReferenceException when trying to click the clear button for query %s. Trying again...",
+					i + 1
+				)
 				self.wait_for_then_click(self.elements.get_clear_bing_search_query_button)
 
 		self.driver.get("https://rewards.bing.com/")
@@ -244,7 +259,7 @@ class RewardsTaskUtils:
 		try:
 			self.wait_for_then_click(self.elements.get_claim_bonus_points_button)
 		except TimeoutException:
-			print("[WARNING] Could not find the 'Claim Bonus Points' button. There are likely no bonus points to claim at this time.")
+			logger.warning("Could not find the 'Claim Bonus Points' button. There are likely no bonus points to claim at this time.")
 
 	def complete_all_tasks(self):
 		# Each task is run independently. The Rewards UI differs by market and
@@ -260,13 +275,23 @@ class RewardsTaskUtils:
 		)
 
 		for name, step in steps:
+			# The tags stay in the message rather than being folded into the
+			# level, they are the per-task outcome summary and reading a run
+			# means scanning for them.
 			try:
 				step()
-				print(f"[OK] {name}")
+				logger.info("[OK] %s", name)
 			except (NoSuchElementException, TimeoutException) as exc:
-				print(f"[SKIP] {name}: not available in this UI variant ({type(exc).__name__})")
+				logger.warning("[SKIP] %s: not available in this UI variant (%s)", name, type(exc).__name__)
 			except Exception as exc:
-				print(f"[FAIL] {name}: {type(exc).__name__}: {exc}")
+				# A selenium exception carries the whole msedgedriver stacktrace
+				# in str(), tens of lines of it, so keep the summary to the
+				# first line and let the traceback on debug hold the rest.
+				message = str(exc).strip().splitlines()
+				logger.error(
+					"[FAIL] %s: %s: %s", name, type(exc).__name__, message[0] if message else "",
+					exc_info=logger.isEnabledFor(logging.DEBUG)
+				)
 
 			# Leave a clean tab state behind for the next task.
 			try:

--- a/src/rewards_tasks.py
+++ b/src/rewards_tasks.py
@@ -81,7 +81,10 @@ class RewardsTaskUtils:
 		except TimeoutException:
 			daily_set_links = self.elements.get_daily_set_elements()
 
-			print(f"[WARNING] Daily set panel only shows {len(daily_set_links)} of {expected_activities} activities")
+			logger.warning(
+				"Daily set panel only shows %s of %s activities",
+				len(daily_set_links), expected_activities
+			)
 
 		# Re-read the panel per index: clicking an activity can re-render it and
 		# stale the captured references.

--- a/src/signin.py
+++ b/src/signin.py
@@ -18,6 +18,7 @@ Sign-in itself stays manual. Nothing here reads, stores or types a credential.
 import contextlib
 import logging
 import os
+import signal
 import socket
 import subprocess
 import sys
@@ -215,6 +216,66 @@ def _report_profile_refused(account: accounts.Account) -> None:
 	logger.error("       one process per user data directory.")
 
 
+def _release_profile_lock(account: accounts.Account, browser_pid: int) -> None:
+	"""Remove the profile lock our own browser left behind.
+
+	Chromium removes SingletonLock when it is quit from inside the browser and
+	leaves it when it exits on a signal, which is the path docker stop and
+	Ctrl-C both take. Measured, not assumed: Edge takes the SIGTERM and exits in
+	under a second, and the lock is still there afterwards.
+
+	Left behind, it names this container, so every later run reads the profile
+	as open on another machine and refuses to start - the failure the README
+	warns about, except caused by the tool meant to make signing in easy.
+
+	The lock is a symlink to "<host>-<pid>". Removing it only when it names this
+	host and the process we started means a lock genuinely held by another
+	machine, which is what the check exists to respect, is never touched.
+	"""
+	lock = os.path.join(account.user_data_dir, "SingletonLock")
+
+	try:
+		owner = os.readlink(lock)
+	except OSError:
+		# Gone already, which is what a window closed from inside looks like.
+		return
+
+	ours = f"{socket.gethostname()}-{browser_pid}"
+
+	if owner != ours:
+		logger.warning(
+			"leaving the profile lock in place: it names %r, not this run (%r)",
+			owner, ours
+		)
+
+		return
+
+	os.unlink(lock)
+	logger.debug("released the profile lock left behind by pid %s", browser_pid)
+
+
+class StopRequest:
+	"""Set when the container is asked to stop.
+
+	The default disposition for SIGTERM ends the process where it stands, so no
+	shutdown runs and the browser is orphaned holding the profile lock. Catching
+	it turns "docker stop" and Ctrl-C into the same orderly close a user gets by
+	shutting the window.
+	"""
+
+	def __init__(self):
+		self.requested = False
+
+	def install(self) -> "StopRequest":
+		for received in (signal.SIGTERM, signal.SIGINT):
+			signal.signal(received, self._request)
+
+		return self
+
+	def _request(self, signum, frame) -> None:
+		self.requested = True
+
+
 def main() -> int:
 	log_utils.setup_logging()
 
@@ -245,13 +306,23 @@ def main() -> int:
 		logger.info("Sign in there, then close the Edge window on that screen.")
 		logger.info("Closing the window ends this container; nothing else needs doing.")
 
-		while browser.poll() is None:
-			time.sleep(0.5)
+		stop = StopRequest().install()
 
-		if time.monotonic() - started < FAST_EXIT_SECONDS:
-			_report_profile_refused(account)
+		try:
+			while browser.poll() is None and not stop.requested:
+				time.sleep(0.5)
 
-			return 1
+			if browser.poll() is not None and time.monotonic() - started < FAST_EXIT_SECONDS:
+				_report_profile_refused(account)
+
+				return 1
+		finally:
+			# Stop the browser first, then clear the lock it leaves behind on
+			# any exit that is not a window close. Order matters: reading the
+			# lock's owner is only meaningful once the process naming it is
+			# known to be gone.
+			_terminate(browser, "Edge")
+			_release_profile_lock(account, browser.pid)
 
 	logger.info("%s: browser closed, sign-in saved to the profile.", account.name)
 

--- a/src/signin.py
+++ b/src/signin.py
@@ -324,6 +324,22 @@ def main() -> int:
 			_terminate(browser, "Edge")
 			_release_profile_lock(account, browser.pid)
 
+	if stop.requested:
+		# Measured, and worth the noise. Chromium writes the session to disk on
+		# its own shutdown and skips that on the fast exit a signal produces, so
+		# a sign-in completed here is simply gone. Reporting success would be a
+		# lie, and a quiet one: the profile looks fine and fails at the next run.
+		logger.warning("%s: stopped before the browser was closed.", account.name)
+		logger.warning("       A sign-in completed just now was probably NOT saved:")
+		logger.warning("       the browser writes it on its own shutdown, which a")
+		logger.warning("       signal skips. Run this again and close the Edge window")
+		logger.warning("       on the noVNC screen instead of interrupting here.")
+
+		# Still zero: stopping when asked is not a failure, and the exit code
+		# already means "the profile was refused" elsewhere. The warning is the
+		# channel for this, not the status.
+		return 0
+
 	logger.info("%s: browser closed, sign-in saved to the profile.", account.name)
 
 	return 0

--- a/src/signin.py
+++ b/src/signin.py
@@ -20,11 +20,20 @@ import logging
 import os
 import socket
 import subprocess
+import sys
 import time
 
 import accounts
+import log_utils
 
 logger = logging.getLogger(__name__)
+
+SIGNIN_URL = "https://rewards.bing.com"
+
+# Edge exits about this fast when it refuses to open the profile at all, which
+# is a different failure from a user closing the window and deserves a
+# different message.
+FAST_EXIT_SECONDS = 3
 
 DISPLAY = ":99"
 
@@ -44,6 +53,31 @@ NOVNC_ROOT = "/usr/share/novnc"
 
 STARTUP_TIMEOUT = 20
 SHUTDOWN_TIMEOUT = 10
+
+
+def account_to_sign_in() -> accounts.Account:
+	"""The single profile this invocation signs in.
+
+	One browser window, so one account. Several names is a user error rather
+	than a reason to guess at which was meant, and the message names them so the
+	reader can see what to run instead.
+
+	Resolution goes through accounts.configured() rather than reimplementing the
+	name rules here. Two implementations drift, and the one that drifts is the
+	one nobody is reading when a name resolves onto the wrong directory.
+	"""
+	configured = accounts.configured()
+
+	if len(configured) > 1:
+		names = ", ".join(account.name for account in configured)
+
+		raise ValueError(
+			f"sign in one account at a time; {accounts.ENV_VAR} names {names}. "
+			f"Run this once per name, starting with "
+			f"{accounts.ENV_VAR}={configured[0].name}"
+		)
+
+	return configured[0]
 
 
 def is_listening(host: str, port: int, timeout: float = 1.0) -> bool:
@@ -153,26 +187,76 @@ def display_stack():
 			_terminate(process, name)
 
 
-def account_to_sign_in() -> accounts.Account:
-	"""The single profile this invocation signs in.
+def browser_command(account: accounts.Account) -> list[str]:
+	"""Edge, headful, on the virtual display, opened at the sign-in page."""
+	return [
+		"microsoft-edge",
+		f"--user-data-dir={account.user_data_dir}",
+		f"--profile-directory={account.profile_name}",
+		# A container runs as root on a filesystem the sandbox cannot use, and
+		# Chromium wants more shared memory than the default 64MB.
+		"--no-sandbox",
+		"--disable-dev-shm-usage",
+		"--window-size=1920,1080",
+		SIGNIN_URL,
+	]
 
-	One browser window, so one account. Several names is a user error rather
-	than a reason to guess at which was meant, and the message names them so the
-	reader can see what to run instead.
 
-	Resolution goes through accounts.configured() rather than reimplementing the
-	name rules here. Two implementations drift, and the one that drifts is the
-	one nobody is reading when a name resolves onto the wrong directory.
+def _report_profile_refused(account: accounts.Account) -> None:
+	"""The message for a browser that exited instead of opening.
+
+	Without this the user is left watching an empty screen in the browser tab,
+	with the reason on a log line they have no cause to read.
 	"""
-	configured = accounts.configured()
+	logger.error("[FAIL] %s: Edge exited instead of opening the profile.", account.name)
+	logger.error("       profile directory: %s", account.user_data_dir)
+	logger.error("       The usual cause is that this profile is already open,")
+	logger.error("       including in a run left over from earlier. Chromium allows")
+	logger.error("       one process per user data directory.")
 
-	if len(configured) > 1:
-		names = ", ".join(account.name for account in configured)
 
-		raise ValueError(
-			f"sign in one account at a time; {accounts.ENV_VAR} names {names}. "
-			f"Run this once per name, starting with "
-			f"{accounts.ENV_VAR}={configured[0].name}"
+def main() -> int:
+	log_utils.setup_logging()
+
+	try:
+		account = account_to_sign_in()
+	except ValueError as exc:
+		logger.error("[FAIL] %s", exc)
+
+		return 2
+
+	with display_stack():
+		browser = subprocess.Popen(
+			browser_command(account),
+			# There is no dbus in a container, so Edge writes about twenty
+			# ERROR lines about failing to reach it before it has drawn
+			# anything. None of them mean the browser is unwell, and left in
+			# they bury the one line the user has to act on.
+			stdout=subprocess.DEVNULL,
+			stderr=subprocess.DEVNULL,
+			env={**os.environ, "DISPLAY": DISPLAY},
 		)
+		started = time.monotonic()
 
-	return configured[0]
+		logger.info("Signing in to the %s profile at %s", account.name, account.user_data_dir)
+		logger.info("")
+		logger.info("    Open http://localhost:%s in a browser on this machine.", BRIDGE_PORT)
+		logger.info("")
+		logger.info("Sign in there, then close the Edge window on that screen.")
+		logger.info("Closing the window ends this container; nothing else needs doing.")
+
+		while browser.poll() is None:
+			time.sleep(0.5)
+
+		if time.monotonic() - started < FAST_EXIT_SECONDS:
+			_report_profile_refused(account)
+
+			return 1
+
+	logger.info("%s: browser closed, sign-in saved to the profile.", account.name)
+
+	return 0
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/src/signin.py
+++ b/src/signin.py
@@ -15,11 +15,142 @@ over noVNC, so the whole flow needs nothing on the host but a web browser:
 Sign-in itself stays manual. Nothing here reads, stores or types a credential.
 """
 
+import contextlib
 import logging
+import os
+import socket
+import subprocess
+import time
 
 import accounts
 
 logger = logging.getLogger(__name__)
+
+DISPLAY = ":99"
+
+# The same geometry main.build_options gives the headless window. The pointer
+# code works in viewport coordinates, so a profile signed in on a smaller screen
+# would carry metrics a run then disagrees with.
+SCREEN = "1920x1080x24"
+
+# Never published. websockify reaches it over loopback inside this container,
+# and x11vnc is bound so that nothing else can.
+VNC_PORT = 5900
+
+# Published, but only onto the host's loopback by the compose file.
+BRIDGE_PORT = 6080
+
+NOVNC_ROOT = "/usr/share/novnc"
+
+STARTUP_TIMEOUT = 20
+SHUTDOWN_TIMEOUT = 10
+
+
+def is_listening(host: str, port: int, timeout: float = 1.0) -> bool:
+	"""Whether something accepts a connection there right now."""
+	try:
+		with socket.create_connection((host, port), timeout=timeout):
+			return True
+	except OSError:
+		return False
+
+
+def _wait_until(predicate, description: str, timeout: int = STARTUP_TIMEOUT) -> None:
+	"""Poll rather than sleep a guessed interval.
+
+	A fixed sleep is either too short on a loaded machine, where it produces a
+	failure that looks like the feature being broken, or too long on every
+	other machine.
+	"""
+	deadline = time.monotonic() + timeout
+
+	while time.monotonic() < deadline:
+		if predicate():
+			return
+
+		time.sleep(0.1)
+
+	raise TimeoutError(f"{description} did not come up within {timeout}s")
+
+
+def _terminate(process: subprocess.Popen, name: str) -> None:
+	"""Ask a process to stop, and insist only if asking fails."""
+	if process.poll() is not None:
+		return
+
+	process.terminate()
+
+	try:
+		process.wait(timeout=SHUTDOWN_TIMEOUT)
+	except subprocess.TimeoutExpired:
+		logger.warning("%s did not stop when asked; killing it", name)
+		process.kill()
+		process.wait()
+
+
+@contextlib.contextmanager
+def display_stack():
+	"""A virtual display, served to the host as a web page.
+
+	Three processes, started in dependency order and stopped in reverse:
+
+	    Xvfb        a screen for a browser that has no monitor
+	    x11vnc      that screen as a VNC server, bound to loopback
+	    websockify  that server as noVNC, which a browser can open
+
+	Only websockify binds every interface, and it has to: docker publishes a
+	port by forwarding to the container's own address, so a bridge bound to
+	loopback here would be unreachable through the published port. The container
+	network is isolated and the compose file publishes onto the host's loopback
+	only, which is where the boundary actually sits.
+	"""
+	processes: list[tuple[str, subprocess.Popen]] = []
+
+	def spawn(name: str, command: list[str]) -> subprocess.Popen:
+		process = subprocess.Popen(
+			command,
+			stdout=subprocess.DEVNULL,
+			stderr=subprocess.DEVNULL,
+			env={**os.environ, "DISPLAY": DISPLAY},
+		)
+		processes.append((name, process))
+
+		return process
+
+	try:
+		spawn("Xvfb", ["Xvfb", DISPLAY, "-screen", "0", SCREEN, "-nolisten", "tcp"])
+
+		# Xvfb has no port to poll. It creates its socket when it is ready to
+		# take clients, so that is the signal.
+		socket_path = f"/tmp/.X11-unix/X{DISPLAY.lstrip(':')}"
+		_wait_until(lambda: os.path.exists(socket_path), "Xvfb")
+
+		spawn("x11vnc", [
+			"x11vnc",
+			"-display", DISPLAY,
+			"-rfbport", str(VNC_PORT),
+			# Not reachable from outside this container, at all.
+			"-localhost",
+			"-nopw",
+			# The user reloading the page must not end the session.
+			"-forever",
+			"-shared",
+			"-quiet",
+		])
+		_wait_until(lambda: is_listening("127.0.0.1", VNC_PORT), "x11vnc")
+
+		spawn("websockify", [
+			"websockify",
+			f"--web={NOVNC_ROOT}",
+			str(BRIDGE_PORT),
+			f"localhost:{VNC_PORT}",
+		])
+		_wait_until(lambda: is_listening("127.0.0.1", BRIDGE_PORT), "websockify")
+
+		yield
+	finally:
+		for name, process in reversed(processes):
+			_terminate(process, name)
 
 
 def account_to_sign_in() -> accounts.Account:

--- a/src/signin.py
+++ b/src/signin.py
@@ -198,6 +198,13 @@ def browser_command(account: accounts.Account) -> list[str]:
 		# Chromium wants more shared memory than the default 64MB.
 		"--no-sandbox",
 		"--disable-dev-shm-usage",
+		# The profile here is always a new one, which is the point, and a new
+		# profile otherwise opens on the first-run terms dialog with the Rewards
+		# page nowhere behind it: the user is told to sign in and is shown a
+		# modal about terms of service instead. A run never meets this because
+		# msedgedriver passes both switches itself.
+		"--no-first-run",
+		"--no-default-browser-check",
 		"--window-size=1920,1080",
 		SIGNIN_URL,
 	]

--- a/src/signin.py
+++ b/src/signin.py
@@ -1,0 +1,47 @@
+"""Sign a profile in from inside the container.
+
+Chromium encrypts cookie values with a key it takes from the operating system.
+On Windows that key is wrapped with DPAPI and tied to the Windows account; on
+macOS it is wrapped with the login Keychain. The container can unwrap neither,
+so a profile signed in on such a host arrives looking healthy and behaving as
+though it were logged out.
+
+The way out is to sign in with the browser that will read the profile. This
+gives that browser a virtual display and puts the display on the user's screen
+over noVNC, so the whole flow needs nothing on the host but a web browser:
+
+    docker compose run --rm --service-ports signin
+
+Sign-in itself stays manual. Nothing here reads, stores or types a credential.
+"""
+
+import logging
+
+import accounts
+
+logger = logging.getLogger(__name__)
+
+
+def account_to_sign_in() -> accounts.Account:
+	"""The single profile this invocation signs in.
+
+	One browser window, so one account. Several names is a user error rather
+	than a reason to guess at which was meant, and the message names them so the
+	reader can see what to run instead.
+
+	Resolution goes through accounts.configured() rather than reimplementing the
+	name rules here. Two implementations drift, and the one that drifts is the
+	one nobody is reading when a name resolves onto the wrong directory.
+	"""
+	configured = accounts.configured()
+
+	if len(configured) > 1:
+		names = ", ".join(account.name for account in configured)
+
+		raise ValueError(
+			f"sign in one account at a time; {accounts.ENV_VAR} names {names}. "
+			f"Run this once per name, starting with "
+			f"{accounts.ENV_VAR}={configured[0].name}"
+		)
+
+	return configured[0]

--- a/src/tab_utils.py
+++ b/src/tab_utils.py
@@ -1,5 +1,8 @@
+import logging
 from selenium.common.exceptions import WebDriverException, JavascriptException
 from selenium import webdriver
+
+logger = logging.getLogger(__name__)
 
 GHOST_TAB_URLS = (
 	"https://ntp.msn.com/edge/ntp?locale=en-US&title=New%20tab&fre=1&dsp=1&sp=Bing&feed_dis=always&en_widget_reg=false&prerender=1&PC=U531", # has fre
@@ -30,7 +33,7 @@ document.dispatchEvent(new Event('visibilitychange'));
 				self.driver.switch_to.window(handle)
 
 				if self.driver.current_url in GHOST_TAB_URLS:
-					print(f"[INFO] Found ghost tab with handle {handle} and URL {self.driver.current_url}.")
+					logger.info("Found ghost tab with handle %s and URL %s.", handle, self.driver.current_url)
 					continue
 
 				self.ensure_focus()
@@ -47,17 +50,17 @@ document.dispatchEvent(new Event('visibilitychange'));
 				self.driver.switch_to.window(handle)
 
 				if self.driver.current_url in GHOST_TAB_URLS:
-					print(f"[INFO] Found ghost tab with handle {handle} and URL {self.driver.current_url}, not closing.")
+					logger.info("Found ghost tab with handle %s and URL %s, not closing.", handle, self.driver.current_url)
 					continue
 
 				tab_url = self.driver.current_url
 
 				try:
 					self.driver.close()
-					print(f"[INFO] Closed tab with handle {handle} and URL {tab_url}.")
+					logger.info("Closed tab with handle %s and URL %s.", handle, tab_url)
 
 				except WebDriverException:
-					print(f"[WARNING] Could not close tab with handle {handle} and URL {tab_url}.")
+					logger.warning("Could not close tab with handle %s and URL %s.", handle, tab_url)
 					self.problematic_tabs.add(handle)
 					pass
 

--- a/src/tab_utils.py
+++ b/src/tab_utils.py
@@ -33,7 +33,7 @@ document.dispatchEvent(new Event('visibilitychange'));
 				self.driver.switch_to.window(handle)
 
 				if self.driver.current_url in GHOST_TAB_URLS:
-					logger.info("Found ghost tab with handle %s and URL %s.", handle, self.driver.current_url)
+					logger.debug("Found ghost tab with handle %s and URL %s.", handle, self.driver.current_url)
 					continue
 
 				self.ensure_focus()
@@ -50,14 +50,18 @@ document.dispatchEvent(new Event('visibilitychange'));
 				self.driver.switch_to.window(handle)
 
 				if self.driver.current_url in GHOST_TAB_URLS:
-					logger.info("Found ghost tab with handle %s and URL %s, not closing.", handle, self.driver.current_url)
+					logger.debug("Found ghost tab with handle %s and URL %s, not closing.", handle, self.driver.current_url)
 					continue
 
 				tab_url = self.driver.current_url
 
 				try:
 					self.driver.close()
-					logger.info("Closed tab with handle %s and URL %s.", handle, tab_url)
+					# Routine bookkeeping, one line per tab. At info it drowned
+					# the task summary: 19 of the 33 records in a full run were
+					# these. The warning below stays at warning, a tab that will
+					# not close is a real problem.
+					logger.debug("Closed tab with handle %s and URL %s.", handle, tab_url)
 
 				except WebDriverException:
 					logger.warning("Could not close tab with handle %s and URL %s.", handle, tab_url)

--- a/tests/test_multi_account.py
+++ b/tests/test_multi_account.py
@@ -1,49 +1,51 @@
-"""Checks for REWARDS_ACCOUNTS.
+"""Tests for running more than one account in a single run.
 
-Five layers, cheapest first:
+Names become directory names, so most of these are about refusing one that
+would resolve somewhere other than where it reads: `..`, an absolute path, and
+the trailing dot Win32 strips but Python's normalisation does not. The rest
+cover the run loop, where one account failing used to end the batch and take
+the remaining accounts with it.
 
-    1. which accounts a configuration produces
-    2. the flags each one hands Edge
-    3. the run loop's ordering, skip-on-failure and exit codes
-    4. one account failing every way it can, without ending the batch
-    5. two real Edge profiles holding two independent, persistent identities
+None of these need a browser. The last case does, and starts Edge twice to show
+that two profiles hold two independent, persistent identities, so it is opt in:
 
-Layers 1 to 4 are pure and need nothing installed. Layer 4 drives the real
-run loop with a stand-in for the browser, so the code under test is the
-shipped one and only selenium is replaced. Layer 5 starts Edge twice and
-reaches bing.com, so it is opt in:
-
-    python tests/test_multi_account.py            # layers 1-4
-    python tests/test_multi_account.py --browser  # all five
-
-Layer 5 is the one that answers "does multi-account work". Two profiles must
-end up with two different identities, and each must keep its own across a
-restart, because that is what a per-account sign-in is made of. It uses
-bing.com's own MUID cookie rather than an injected one: a cookie added through
-webdriver is not written to the profile the way a Set-Cookie is, so it proves
-nothing about a sign-in surviving.
+	python -m unittest discover -s tests
+	REWARDS_BROWSER_TESTS=1 python -m unittest discover -s tests
 """
 
 import logging
 import os
 import shutil
 import sys
+import unittest
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-FAILURES = []
+from selenium.common.exceptions import (
+	NoSuchDriverException,
+	SessionNotCreatedException,
+	WebDriverException,
+)
 
+import accounts
+import main
+from constants import USER_DATA_DIR
 
-def check(label, got, want):
-	if got == want:
-		print(f"  ok    {label}")
-
-		return True
-
-	print(f"  FAIL  {label}\n          got  {got!r}\n          want {want!r}")
-	FAILURES.append(label)
-
-	return False
+# Names that have to be refused, with the reason each one is not simply a
+# directory sitting under data-dir.
+REFUSED_NAMES = [
+	# relative traversal
+	"..", ".", "../escape", "..\\escape", "a/b", "a\\b",
+	# absolute, drive relative and UNC
+	"/etc", "\\", "/", "C:", "C:\\Windows", "\\\\server\\share",
+	# expanded by a shell somewhere else, not here
+	"~", "%TEMP%", "$HOME",
+	# Win32 strips a trailing dot from a path component and Python does not, so
+	# "personal." is the "personal" directory and "..." is data-dir itself
+	"...", "....", "personal.", "personal..",
+	# shell and filesystem metacharacters
+	"a b", "a:b", "a;b", "a|b", "a*b", "a?b", "a<b",
+]
 
 
 def accounts_for(value):
@@ -56,202 +58,155 @@ def accounts_for(value):
 	return accounts.configured()
 
 
-# --------------------------------------------------------------------------
-# 1. which accounts a configuration produces
-# --------------------------------------------------------------------------
+class EnvironmentTestCase(unittest.TestCase):
+	"""Restores everything these tests reach into, so ordering cannot matter."""
 
-def test_configuration():
-	print("\n[1] account configuration")
-
-	default = accounts_for(None)
-	check("unset gives one account", [a.name for a in default], ["default"])
-	check("unset uses the existing profile directory", default[0].user_data_dir, USER_DATA_DIR)
-	check("unset is the default profile", default[0].is_default, True)
-
-	check("two names, in order", [a.name for a in accounts_for("personal,spare")], ["personal", "spare"])
-	check("surrounding whitespace ignored", [a.name for a in accounts_for(" personal , spare ")], ["personal", "spare"])
-	check("empty entries dropped", [a.name for a in accounts_for("personal,,spare,")], ["personal", "spare"])
-	check("blank value falls back to default", [a.name for a in accounts_for("   ")], ["default"])
-	check("duplicates collapse, case insensitively", [a.name for a in accounts_for("personal,PERSONAL,spare")], ["personal", "spare"])
-
-	# Names become directory names. Anything that resolves outside the profile
-	# directory, or onto a directory another entry already owns, has to be
-	# refused rather than quietly writing somewhere else.
-	refused = [
-		# relative traversal
-		"..", ".", "../escape", "..\\escape", "a/b", "a\\b",
-		# absolute, drive-relative and UNC
-		"/etc", "\\", "/", "C:", "C:\\Windows", "\\\\server\\share",
-		# expanded elsewhere, not here
-		"~", "%TEMP%", "$HOME",
-		# Win32 strips trailing dots, so these are not the directories they read
-		# as: "personal." is "personal", and "..." is data-dir itself
-		"...", "....", "personal.", "personal..",
-		# shell and filesystem metacharacters
-		"a b", "a:b", "a;b", "a|b", "a*b", "a?b", "a<b",
-	]
-
-	for name in refused:
-		try:
-			accounts_for(f"good,{name}")
-			rejected = False
-		except ValueError:
-			rejected = True
-
-		check(f"refused as a directory name: {name!r}", rejected, True)
-
-	# The leading dot is fine, it is only the trailing one that moves.
-	check("a leading dot is still a usable name", [a.name for a in accounts_for(".hidden")], [".hidden"])
-
-	named = accounts_for("personal,spare")
-	check("one directory per account", len({a.user_data_dir for a in named}), 2)
-
-	# Distinct strings are not enough. Two names can spell one directory, which
-	# is what the trailing dot did, so compare where the paths actually land.
-	check(
-		"one directory per account after the filesystem resolves them",
-		len({os.path.realpath(a.user_data_dir) for a in named}), 2
-	)
-
-	root = os.path.realpath(USER_DATA_DIR)
-	inside = all(
-		os.path.commonpath([root, os.path.realpath(a.user_data_dir)]) == root
-		and os.path.realpath(a.user_data_dir) != root
-		for a in named
-	)
-	check("every directory sits under the profile directory", inside, True)
-	check("named accounts are not the default profile", [a.is_default for a in named], [False, False])
+	def setUp(self):
+		self.addCleanup(os.environ.pop, accounts.ENV_VAR, None)
 
 
-# --------------------------------------------------------------------------
-# 2. the flags each one hands Edge
-# --------------------------------------------------------------------------
+class TestAccountConfiguration(EnvironmentTestCase):
+	def test_unset_is_the_existing_single_profile(self):
+		configured = accounts_for(None)
 
-def test_options():
-	print("\n[2] the flags Edge is handed")
+		self.assertEqual([a.name for a in configured], ["default"])
+		self.assertEqual(configured[0].user_data_dir, USER_DATA_DIR)
+		self.assertTrue(configured[0].is_default)
 
-	seen = []
+	def test_blank_falls_back_to_the_single_profile(self):
+		self.assertEqual([a.name for a in accounts_for("   ")], ["default"])
 
-	for account in accounts_for("personal,spare"):
-		args = main.build_options(account).arguments
-		user_data = [a for a in args if a.startswith("--user-data-dir=")]
-		profile = [a for a in args if a.startswith("--profile-directory=")]
+	def test_names_are_taken_in_order(self):
+		self.assertEqual([a.name for a in accounts_for("personal,spare")], ["personal", "spare"])
 
-		check(f"{account.name}: exactly one --user-data-dir", len(user_data), 1)
-		check(f"{account.name}: exactly one --profile-directory", len(profile), 1)
-		seen.append(user_data[0])
+	def test_surrounding_whitespace_and_empty_entries_are_ignored(self):
+		self.assertEqual([a.name for a in accounts_for(" personal , spare ")], ["personal", "spare"])
+		self.assertEqual([a.name for a in accounts_for("personal,,spare,")], ["personal", "spare"])
 
-	check("the two profiles differ on the command line", len(set(seen)), 2)
+	def test_duplicates_collapse_case_insensitively(self):
+		# Running the same profile twice earns nothing the second time and
+		# doubles the length of the run.
+		self.assertEqual(
+			[a.name for a in accounts_for("personal,PERSONAL,spare")], ["personal", "spare"]
+		)
+
+	def test_unusable_directory_names_are_refused(self):
+		for name in REFUSED_NAMES:
+			with self.subTest(name=name):
+				with self.assertRaises(ValueError):
+					accounts_for(f"good,{name}")
+
+	def test_a_leading_dot_is_still_usable(self):
+		# Only the trailing dot moves the directory.
+		self.assertEqual([a.name for a in accounts_for(".hidden")], [".hidden"])
+
+	def test_each_account_gets_its_own_directory(self):
+		named = accounts_for("personal,spare")
+
+		self.assertEqual(len({a.user_data_dir for a in named}), 2)
+		# Distinct strings are not enough: two names can spell one directory,
+		# which is what the trailing dot did, so compare where they land.
+		self.assertEqual(len({os.path.realpath(a.user_data_dir) for a in named}), 2)
+
+	def test_every_directory_sits_under_the_profile_directory(self):
+		root = os.path.realpath(USER_DATA_DIR)
+
+		for account in accounts_for("personal,spare"):
+			with self.subTest(account=account.name):
+				resolved = os.path.realpath(account.user_data_dir)
+
+				self.assertEqual(os.path.commonpath([root, resolved]), root)
+				self.assertNotEqual(resolved, root)
+				self.assertFalse(account.is_default)
 
 
-# --------------------------------------------------------------------------
-# 3. the run loop
-# --------------------------------------------------------------------------
+class TestEdgeOptions(EnvironmentTestCase):
+	def test_each_account_is_handed_its_own_profile(self):
+		seen = []
 
-def test_run_loop():
-	print("\n[3] the run loop")
+		for account in accounts_for("personal,spare"):
+			arguments = main.build_options(account).arguments
+			user_data = [a for a in arguments if a.startswith("--user-data-dir=")]
+			profile = [a for a in arguments if a.startswith("--profile-directory=")]
 
-	accounts_for("personal,spare")
-	os.environ["REWARDS_HEADLESS"] = "1"
-	main.HEADLESS = True  # so main() does not wait on input()
+			with self.subTest(account=account.name):
+				self.assertEqual(len(user_data), 1)
+				self.assertEqual(len(profile), 1)
 
-	real = main.run_account
-	calls = []
+			seen.append(user_data[0])
 
-	try:
-		# The first profile fails to start; the second must still run.
-		main.run_account = lambda a: (calls.append(a.name), a.name != "personal")[1]
-		code = main.main()
+		self.assertEqual(len(set(seen)), 2)
 
-		check("every account attempted, in order", calls, ["personal", "spare"])
-		check("a profile that fails to start does not end the run", len(calls), 2)
-		check("exit code 0 while at least one ran", code, 0)
 
-		calls.clear()
-		main.run_account = lambda a: (calls.append(a.name), False)[1]
-		check("exit code 1 when none ran", main.main(), 1)
+class RunLoopTestCase(EnvironmentTestCase):
+	"""main() drives real browsers, so both entry points are replaced here."""
 
-		calls.clear()
-		main.run_account = lambda a: (calls.append(a.name), True)[1]
+	def setUp(self):
+		super().setUp()
+
+		# main() waits on input() when it is not headless, which would hang.
+		headless = main.HEADLESS
+		main.HEADLESS = True
+		self.addCleanup(setattr, main, "HEADLESS", headless)
+
+		# main() reports per account at info, and the failure paths at error, by
+		# design. The assertions are what reports the outcome here, so keep the
+		# suite's own output to what unittest prints.
+		logging.disable(logging.CRITICAL)
+		self.addCleanup(logging.disable, logging.NOTSET)
+
+
+class TestRunLoop(RunLoopTestCase):
+	def setUp(self):
+		super().setUp()
+
+		self.calls = []
+		real = main.run_account
+		self.addCleanup(setattr, main, "run_account", real)
+
+	def _record(self, started):
+		def run_account(account):
+			self.calls.append(account.name)
+
+			return started(account.name)
+
+		main.run_account = run_account
+
+	def test_a_profile_that_fails_to_start_does_not_end_the_run(self):
+		accounts_for("personal,spare")
+		self._record(lambda name: name != "personal")
+
+		self.assertEqual(main.main(), 0)
+		self.assertEqual(self.calls, ["personal", "spare"])
+
+	def test_exit_code_is_one_when_no_account_ran(self):
+		accounts_for("personal,spare")
+		self._record(lambda name: False)
+
+		self.assertEqual(main.main(), 1)
+		self.assertEqual(self.calls, ["personal", "spare"])
+
+	def test_unset_still_runs_the_single_profile(self):
 		accounts_for(None)
-		check("unset still runs the single profile", (main.main(), calls), (0, ["default"]))
-	finally:
-		main.run_account = real
+		self._record(lambda name: True)
+
+		self.assertEqual(main.main(), 0)
+		self.assertEqual(self.calls, ["default"])
 
 
-# --------------------------------------------------------------------------
-# 4. one account failing, without ending the batch
-# --------------------------------------------------------------------------
+class TestFailureIsolation(RunLoopTestCase):
+	"""One account failing, every way it can, without ending the batch.
 
-def failing_run(fail_at, exc):
-	"""Three accounts through the real run loop, with the middle one failing.
-
-	Only selenium is replaced. run_account and main() are the shipped ones, so
-	what is measured is where their exception handling actually reaches.
+	Only selenium is replaced: run_account and main() are the shipped ones, so
+	what is measured is where their exception handling actually reaches. Before
+	this, only "profile already open" was handled by name and everything else
+	took the remaining accounts with it.
 	"""
-	started, quit_cleanly = [], []
 
-	def account_of(options):
-		flag = next(a for a in options.arguments if a.startswith("--user-data-dir="))
-
-		return os.path.basename(flag.split("=", 1)[1])
-
-	class Driver:
-		def __init__(self, options):
-			self.name = account_of(options)
-			started.append(self.name)
-
-			if self.name == "two" and fail_at == "start":
-				raise exc
-
-		def quit(self):
-			if self.name == "two" and fail_at == "quit":
-				raise exc
-
-			quit_cleanly.append(self.name)
-
-	class Tasks:
-		def __init__(self, driver):
-			self.driver = driver
-
-			if driver.name == "two" and fail_at == "connect":
-				raise exc
-
-		def complete_all_tasks(self):
-			if self.driver.name == "two" and fail_at == "tasks":
-				raise exc
-
-	real_edge, real_tasks = main.webdriver.Edge, main.rewards_tasks.RewardsTaskUtils
-	main.webdriver.Edge, main.rewards_tasks.RewardsTaskUtils = Driver, Tasks
-
-	try:
-		accounts_for("one,two,three")
-		outcome = main.main()
-	except BaseException as raised:  # noqa: BLE001 - the point is to notice it
-		outcome = f"raised {type(raised).__name__}"
-	finally:
-		main.webdriver.Edge, main.rewards_tasks.RewardsTaskUtils = real_edge, real_tasks
-
-	return started, quit_cleanly, outcome
-
-
-def test_failure_isolation():
-	print("\n[4] one account failing, without ending the batch")
-
-	os.environ["REWARDS_HEADLESS"] = "1"
-	main.HEADLESS = True
-
-	# Every way the middle account can go wrong. Only the first of these was
-	# handled by name; the rest reached main() and took account three with them.
-	from selenium.common.exceptions import (
-		NoSuchDriverException,
-		SessionNotCreatedException,
-		WebDriverException,
-	)
-
-	cases = [
+	# (label, where it fails, the exception raised)
+	CASES = [
 		("the profile is already open", "start", SessionNotCreatedException("profile in use")),
-		("the driver will not start", "start", WebDriverException("browser and driver version mismatch")),
+		("the driver will not start", "start", WebDriverException("driver version mismatch")),
 		("there is no driver installed", "start", NoSuchDriverException("msedgedriver not found")),
 		("the profile directory is unwritable", "start", PermissionError(13, "Permission denied")),
 		("the first page never loads", "connect", WebDriverException("net::ERR_NAME_NOT_RESOLVED")),
@@ -259,101 +214,130 @@ def test_failure_isolation():
 		("the browser will not shut down", "quit", WebDriverException("browser already gone")),
 	]
 
-	# The failure paths log at error level by design; the checks below are what
-	# reports the outcome, so keep the output readable.
-	logging.disable(logging.CRITICAL)
+	def setUp(self):
+		super().setUp()
 
-	try:
-		for label, fail_at, exc in cases:
-			started, quit_cleanly, outcome = failing_run(fail_at, exc)
+		edge, tasks = main.webdriver.Edge, main.rewards_tasks.RewardsTaskUtils
+		self.addCleanup(setattr, main.webdriver, "Edge", edge)
+		self.addCleanup(setattr, main.rewards_tasks, "RewardsTaskUtils", tasks)
 
-			check(f"{label}: the other accounts still run", started, ["one", "two", "three"])
-			check(f"{label}: main() still returns an exit code", outcome, 0)
+	def _install(self, fail_at, exc, started, quit_cleanly):
+		def account_of(options):
+			flag = next(a for a in options.arguments if a.startswith("--user-data-dir="))
 
-			# Whatever went wrong, the browsers that did start have to be shut
-			# down, or their profiles stay locked against the next run.
-			expected_quit = ["one", "three"] if fail_at in ("start", "quit") else ["one", "two", "three"]
-			check(f"{label}: every started browser was closed", quit_cleanly, expected_quit)
-	finally:
-		logging.disable(logging.NOTSET)
+			return os.path.basename(flag.split("=", 1)[1])
 
-	# A lone account is the unset, unchanged path. Its failure has nothing left
-	# to protect, so it must still come out as a failing exit code rather than
-	# being swallowed into a success.
-	accounts_for(None)
-	real = main.run_account
-	logging.disable(logging.CRITICAL)
+		class Driver:
+			def __init__(self, options):
+				self.name = account_of(options)
+				started.append(self.name)
 
-	try:
+				if self.name == "two" and fail_at == "start":
+					raise exc
+
+			def quit(self):
+				if self.name == "two" and fail_at == "quit":
+					raise exc
+
+				quit_cleanly.append(self.name)
+
+		class Tasks:
+			def __init__(self, driver):
+				self.driver = driver
+
+				if driver.name == "two" and fail_at == "connect":
+					raise exc
+
+			def complete_all_tasks(self):
+				if self.driver.name == "two" and fail_at == "tasks":
+					raise exc
+
+		main.webdriver.Edge = Driver
+		main.rewards_tasks.RewardsTaskUtils = Tasks
+
+	def test_the_remaining_accounts_still_run(self):
+		for label, fail_at, exc in self.CASES:
+			with self.subTest(case=label):
+				started, quit_cleanly = [], []
+				self._install(fail_at, exc, started, quit_cleanly)
+				accounts_for("one,two,three")
+
+				self.assertEqual(main.main(), 0)
+				self.assertEqual(started, ["one", "two", "three"])
+
+				# Whatever went wrong, a browser that started has to be shut
+				# down or its profile stays locked against the next run.
+				expected = ["one", "three"] if fail_at in ("start", "quit") else ["one", "two", "three"]
+				self.assertEqual(quit_cleanly, expected)
+
+	def test_a_lone_accounts_failure_is_still_a_failing_exit_code(self):
+		# The unset, unchanged path. Its failure has nothing left to protect, so
+		# it must not be swallowed into a success.
+		accounts_for(None)
+		real = main.run_account
+		self.addCleanup(setattr, main, "run_account", real)
+
 		def boom(_):
 			raise WebDriverException("chrome not reachable")
 
 		main.run_account = boom
-		check("a lone account's failure is still exit code 1", main.main(), 1)
-	finally:
-		main.run_account = real
-		logging.disable(logging.NOTSET)
+
+		self.assertEqual(main.main(), 1)
 
 
-# --------------------------------------------------------------------------
-# 5. two real profiles, two independent identities
-# --------------------------------------------------------------------------
+@unittest.skipUnless(
+	os.environ.get("REWARDS_BROWSER_TESTS"),
+	"starts Edge twice; set REWARDS_BROWSER_TESTS=1 to run",
+)
+class TestTwoRealProfiles(EnvironmentTestCase):
+	"""Two profiles, two independent identities, each surviving a restart.
 
-def identity_of(account):
-	"""bing.com's MUID for this profile: server set, and persistent."""
-	from selenium import webdriver
+	Keyed on bing.com's own MUID rather than an injected cookie: one added
+	through webdriver is not written to the profile the way a Set-Cookie is, so
+	it would prove nothing about a sign-in outliving the browser.
+	"""
 
-	driver = webdriver.Edge(options=main.build_options(account))
+	def setUp(self):
+		super().setUp()
 
-	try:
-		driver.get("https://www.bing.com")
-		cookie = driver.get_cookie("MUID")
+		self.first, self.second = accounts_for("mat_a,mat_b")
 
-		return cookie["value"] if cookie else None
-	finally:
-		driver.quit()
+		for account in (self.first, self.second):
+			self.addCleanup(shutil.rmtree, account.user_data_dir, ignore_errors=True)
 
+	def identity_of(self, account):
+		from selenium import webdriver
 
-def test_real_profiles():
-	print("\n[5] two real Edge profiles")
+		driver = webdriver.Edge(options=main.build_options(account))
 
-	first, second = accounts_for("mat_a,mat_b")
+		try:
+			driver.get("https://www.bing.com")
+			cookie = driver.get_cookie("MUID")
 
-	try:
-		a_before = identity_of(first)
-		b_before = identity_of(second)
+			return cookie["value"] if cookie else None
+		finally:
+			driver.quit()
 
-		check("first profile gets an identity", a_before is not None, True)
-		check("second profile gets an identity", b_before is not None, True)
-		check("the two profiles are different identities", a_before != b_before, True)
+	def test_two_profiles_hold_two_persistent_identities(self):
+		first_id = self.identity_of(self.first)
+		second_id = self.identity_of(self.second)
 
-		check("first profile keeps its identity across a restart", identity_of(first), a_before)
-		check("second profile keeps its identity across a restart", identity_of(second), b_before)
-		check("and they are still distinct", identity_of(first) != identity_of(second), True)
-		check("both directories exist", [os.path.isdir(a.user_data_dir) for a in (first, second)], [True, True])
-		check(
-			"and they are two directories, not one",
-			len({os.path.realpath(a.user_data_dir) for a in (first, second)}), 2
+		self.assertIsNotNone(first_id)
+		self.assertIsNotNone(second_id)
+		self.assertNotEqual(first_id, second_id)
+
+		# The point of a profile per account: the identity has to outlive the
+		# browser, or a sign-in would not either.
+		self.assertEqual(self.identity_of(self.first), first_id)
+		self.assertEqual(self.identity_of(self.second), second_id)
+
+		for account in (self.first, self.second):
+			self.assertTrue(os.path.isdir(account.user_data_dir))
+
+		self.assertEqual(
+			len({os.path.realpath(a.user_data_dir) for a in (self.first, self.second)}), 2
 		)
-	finally:
-		for account in (first, second):
-			shutil.rmtree(account.user_data_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":
-	import accounts
-	import main
-	from constants import USER_DATA_DIR
-
-	test_configuration()
-	test_options()
-	test_run_loop()
-	test_failure_isolation()
-
-	if "--browser" in sys.argv:
-		test_real_profiles()
-	else:
-		print("\n[5] skipped, pass --browser to start Edge")
-
-	print("\n" + (f"{len(FAILURES)} failed: " + "; ".join(FAILURES) if FAILURES else "all checks passed"))
-	sys.exit(1 if FAILURES else 0)
+	unittest.main()

--- a/tests/test_multi_account.py
+++ b/tests/test_multi_account.py
@@ -1,0 +1,359 @@
+"""Checks for REWARDS_ACCOUNTS.
+
+Five layers, cheapest first:
+
+    1. which accounts a configuration produces
+    2. the flags each one hands Edge
+    3. the run loop's ordering, skip-on-failure and exit codes
+    4. one account failing every way it can, without ending the batch
+    5. two real Edge profiles holding two independent, persistent identities
+
+Layers 1 to 4 are pure and need nothing installed. Layer 4 drives the real
+run loop with a stand-in for the browser, so the code under test is the
+shipped one and only selenium is replaced. Layer 5 starts Edge twice and
+reaches bing.com, so it is opt in:
+
+    python tests/test_multi_account.py            # layers 1-4
+    python tests/test_multi_account.py --browser  # all five
+
+Layer 5 is the one that answers "does multi-account work". Two profiles must
+end up with two different identities, and each must keep its own across a
+restart, because that is what a per-account sign-in is made of. It uses
+bing.com's own MUID cookie rather than an injected one: a cookie added through
+webdriver is not written to the profile the way a Set-Cookie is, so it proves
+nothing about a sign-in surviving.
+"""
+
+import logging
+import os
+import shutil
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+
+FAILURES = []
+
+
+def check(label, got, want):
+	if got == want:
+		print(f"  ok    {label}")
+
+		return True
+
+	print(f"  FAIL  {label}\n          got  {got!r}\n          want {want!r}")
+	FAILURES.append(label)
+
+	return False
+
+
+def accounts_for(value):
+	"""configured() under a given REWARDS_ACCOUNTS, or ValueError."""
+	if value is None:
+		os.environ.pop(accounts.ENV_VAR, None)
+	else:
+		os.environ[accounts.ENV_VAR] = value
+
+	return accounts.configured()
+
+
+# --------------------------------------------------------------------------
+# 1. which accounts a configuration produces
+# --------------------------------------------------------------------------
+
+def test_configuration():
+	print("\n[1] account configuration")
+
+	default = accounts_for(None)
+	check("unset gives one account", [a.name for a in default], ["default"])
+	check("unset uses the existing profile directory", default[0].user_data_dir, USER_DATA_DIR)
+	check("unset is the default profile", default[0].is_default, True)
+
+	check("two names, in order", [a.name for a in accounts_for("personal,spare")], ["personal", "spare"])
+	check("surrounding whitespace ignored", [a.name for a in accounts_for(" personal , spare ")], ["personal", "spare"])
+	check("empty entries dropped", [a.name for a in accounts_for("personal,,spare,")], ["personal", "spare"])
+	check("blank value falls back to default", [a.name for a in accounts_for("   ")], ["default"])
+	check("duplicates collapse, case insensitively", [a.name for a in accounts_for("personal,PERSONAL,spare")], ["personal", "spare"])
+
+	# Names become directory names. Anything that resolves outside the profile
+	# directory, or onto a directory another entry already owns, has to be
+	# refused rather than quietly writing somewhere else.
+	refused = [
+		# relative traversal
+		"..", ".", "../escape", "..\\escape", "a/b", "a\\b",
+		# absolute, drive-relative and UNC
+		"/etc", "\\", "/", "C:", "C:\\Windows", "\\\\server\\share",
+		# expanded elsewhere, not here
+		"~", "%TEMP%", "$HOME",
+		# Win32 strips trailing dots, so these are not the directories they read
+		# as: "personal." is "personal", and "..." is data-dir itself
+		"...", "....", "personal.", "personal..",
+		# shell and filesystem metacharacters
+		"a b", "a:b", "a;b", "a|b", "a*b", "a?b", "a<b",
+	]
+
+	for name in refused:
+		try:
+			accounts_for(f"good,{name}")
+			rejected = False
+		except ValueError:
+			rejected = True
+
+		check(f"refused as a directory name: {name!r}", rejected, True)
+
+	# The leading dot is fine, it is only the trailing one that moves.
+	check("a leading dot is still a usable name", [a.name for a in accounts_for(".hidden")], [".hidden"])
+
+	named = accounts_for("personal,spare")
+	check("one directory per account", len({a.user_data_dir for a in named}), 2)
+
+	# Distinct strings are not enough. Two names can spell one directory, which
+	# is what the trailing dot did, so compare where the paths actually land.
+	check(
+		"one directory per account after the filesystem resolves them",
+		len({os.path.realpath(a.user_data_dir) for a in named}), 2
+	)
+
+	root = os.path.realpath(USER_DATA_DIR)
+	inside = all(
+		os.path.commonpath([root, os.path.realpath(a.user_data_dir)]) == root
+		and os.path.realpath(a.user_data_dir) != root
+		for a in named
+	)
+	check("every directory sits under the profile directory", inside, True)
+	check("named accounts are not the default profile", [a.is_default for a in named], [False, False])
+
+
+# --------------------------------------------------------------------------
+# 2. the flags each one hands Edge
+# --------------------------------------------------------------------------
+
+def test_options():
+	print("\n[2] the flags Edge is handed")
+
+	seen = []
+
+	for account in accounts_for("personal,spare"):
+		args = main.build_options(account).arguments
+		user_data = [a for a in args if a.startswith("--user-data-dir=")]
+		profile = [a for a in args if a.startswith("--profile-directory=")]
+
+		check(f"{account.name}: exactly one --user-data-dir", len(user_data), 1)
+		check(f"{account.name}: exactly one --profile-directory", len(profile), 1)
+		seen.append(user_data[0])
+
+	check("the two profiles differ on the command line", len(set(seen)), 2)
+
+
+# --------------------------------------------------------------------------
+# 3. the run loop
+# --------------------------------------------------------------------------
+
+def test_run_loop():
+	print("\n[3] the run loop")
+
+	accounts_for("personal,spare")
+	os.environ["REWARDS_HEADLESS"] = "1"
+	main.HEADLESS = True  # so main() does not wait on input()
+
+	real = main.run_account
+	calls = []
+
+	try:
+		# The first profile fails to start; the second must still run.
+		main.run_account = lambda a: (calls.append(a.name), a.name != "personal")[1]
+		code = main.main()
+
+		check("every account attempted, in order", calls, ["personal", "spare"])
+		check("a profile that fails to start does not end the run", len(calls), 2)
+		check("exit code 0 while at least one ran", code, 0)
+
+		calls.clear()
+		main.run_account = lambda a: (calls.append(a.name), False)[1]
+		check("exit code 1 when none ran", main.main(), 1)
+
+		calls.clear()
+		main.run_account = lambda a: (calls.append(a.name), True)[1]
+		accounts_for(None)
+		check("unset still runs the single profile", (main.main(), calls), (0, ["default"]))
+	finally:
+		main.run_account = real
+
+
+# --------------------------------------------------------------------------
+# 4. one account failing, without ending the batch
+# --------------------------------------------------------------------------
+
+def failing_run(fail_at, exc):
+	"""Three accounts through the real run loop, with the middle one failing.
+
+	Only selenium is replaced. run_account and main() are the shipped ones, so
+	what is measured is where their exception handling actually reaches.
+	"""
+	started, quit_cleanly = [], []
+
+	def account_of(options):
+		flag = next(a for a in options.arguments if a.startswith("--user-data-dir="))
+
+		return os.path.basename(flag.split("=", 1)[1])
+
+	class Driver:
+		def __init__(self, options):
+			self.name = account_of(options)
+			started.append(self.name)
+
+			if self.name == "two" and fail_at == "start":
+				raise exc
+
+		def quit(self):
+			if self.name == "two" and fail_at == "quit":
+				raise exc
+
+			quit_cleanly.append(self.name)
+
+	class Tasks:
+		def __init__(self, driver):
+			self.driver = driver
+
+			if driver.name == "two" and fail_at == "connect":
+				raise exc
+
+		def complete_all_tasks(self):
+			if self.driver.name == "two" and fail_at == "tasks":
+				raise exc
+
+	real_edge, real_tasks = main.webdriver.Edge, main.rewards_tasks.RewardsTaskUtils
+	main.webdriver.Edge, main.rewards_tasks.RewardsTaskUtils = Driver, Tasks
+
+	try:
+		accounts_for("one,two,three")
+		outcome = main.main()
+	except BaseException as raised:  # noqa: BLE001 - the point is to notice it
+		outcome = f"raised {type(raised).__name__}"
+	finally:
+		main.webdriver.Edge, main.rewards_tasks.RewardsTaskUtils = real_edge, real_tasks
+
+	return started, quit_cleanly, outcome
+
+
+def test_failure_isolation():
+	print("\n[4] one account failing, without ending the batch")
+
+	os.environ["REWARDS_HEADLESS"] = "1"
+	main.HEADLESS = True
+
+	# Every way the middle account can go wrong. Only the first of these was
+	# handled by name; the rest reached main() and took account three with them.
+	from selenium.common.exceptions import (
+		NoSuchDriverException,
+		SessionNotCreatedException,
+		WebDriverException,
+	)
+
+	cases = [
+		("the profile is already open", "start", SessionNotCreatedException("profile in use")),
+		("the driver will not start", "start", WebDriverException("browser and driver version mismatch")),
+		("there is no driver installed", "start", NoSuchDriverException("msedgedriver not found")),
+		("the profile directory is unwritable", "start", PermissionError(13, "Permission denied")),
+		("the first page never loads", "connect", WebDriverException("net::ERR_NAME_NOT_RESOLVED")),
+		("the browser dies mid-run", "tasks", WebDriverException("chrome not reachable")),
+		("the browser will not shut down", "quit", WebDriverException("browser already gone")),
+	]
+
+	# The failure paths log at error level by design; the checks below are what
+	# reports the outcome, so keep the output readable.
+	logging.disable(logging.CRITICAL)
+
+	try:
+		for label, fail_at, exc in cases:
+			started, quit_cleanly, outcome = failing_run(fail_at, exc)
+
+			check(f"{label}: the other accounts still run", started, ["one", "two", "three"])
+			check(f"{label}: main() still returns an exit code", outcome, 0)
+
+			# Whatever went wrong, the browsers that did start have to be shut
+			# down, or their profiles stay locked against the next run.
+			expected_quit = ["one", "three"] if fail_at in ("start", "quit") else ["one", "two", "three"]
+			check(f"{label}: every started browser was closed", quit_cleanly, expected_quit)
+	finally:
+		logging.disable(logging.NOTSET)
+
+	# A lone account is the unset, unchanged path. Its failure has nothing left
+	# to protect, so it must still come out as a failing exit code rather than
+	# being swallowed into a success.
+	accounts_for(None)
+	real = main.run_account
+	logging.disable(logging.CRITICAL)
+
+	try:
+		def boom(_):
+			raise WebDriverException("chrome not reachable")
+
+		main.run_account = boom
+		check("a lone account's failure is still exit code 1", main.main(), 1)
+	finally:
+		main.run_account = real
+		logging.disable(logging.NOTSET)
+
+
+# --------------------------------------------------------------------------
+# 5. two real profiles, two independent identities
+# --------------------------------------------------------------------------
+
+def identity_of(account):
+	"""bing.com's MUID for this profile: server set, and persistent."""
+	from selenium import webdriver
+
+	driver = webdriver.Edge(options=main.build_options(account))
+
+	try:
+		driver.get("https://www.bing.com")
+		cookie = driver.get_cookie("MUID")
+
+		return cookie["value"] if cookie else None
+	finally:
+		driver.quit()
+
+
+def test_real_profiles():
+	print("\n[5] two real Edge profiles")
+
+	first, second = accounts_for("mat_a,mat_b")
+
+	try:
+		a_before = identity_of(first)
+		b_before = identity_of(second)
+
+		check("first profile gets an identity", a_before is not None, True)
+		check("second profile gets an identity", b_before is not None, True)
+		check("the two profiles are different identities", a_before != b_before, True)
+
+		check("first profile keeps its identity across a restart", identity_of(first), a_before)
+		check("second profile keeps its identity across a restart", identity_of(second), b_before)
+		check("and they are still distinct", identity_of(first) != identity_of(second), True)
+		check("both directories exist", [os.path.isdir(a.user_data_dir) for a in (first, second)], [True, True])
+		check(
+			"and they are two directories, not one",
+			len({os.path.realpath(a.user_data_dir) for a in (first, second)}), 2
+		)
+	finally:
+		for account in (first, second):
+			shutil.rmtree(account.user_data_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+	import accounts
+	import main
+	from constants import USER_DATA_DIR
+
+	test_configuration()
+	test_options()
+	test_run_loop()
+	test_failure_isolation()
+
+	if "--browser" in sys.argv:
+		test_real_profiles()
+	else:
+		print("\n[5] skipped, pass --browser to start Edge")
+
+	print("\n" + (f"{len(FAILURES)} failed: " + "; ".join(FAILURES) if FAILURES else "all checks passed"))
+	sys.exit(1 if FAILURES else 0)

--- a/tests/test_signin.py
+++ b/tests/test_signin.py
@@ -104,6 +104,32 @@ class TestAccountSelection(EnvironmentTestCase):
 			signin.account_to_sign_in()
 
 
+class TestBrowserCommand(EnvironmentTestCase):
+	"""What the browser is told to do decides what the user first sees.
+
+	Cheap to assert here and expensive to notice otherwise: the failure is a
+	browser that came up perfectly well on the wrong thing, which reads as the
+	sign-in working right up until nobody can find where to type.
+	"""
+
+	def test_the_first_run_dialog_is_skipped(self):
+		"""Every sign-in is a new profile, and a new profile opens on the terms
+		dialog rather than the page it was handed. Without these switches the
+		first thing on the noVNC screen is a modal about terms of service with
+		no Rewards page behind it. A run never meets this, because msedgedriver
+		passes the same two switches itself, so only this path needs them.
+		"""
+		command = signin.browser_command(signin.account_to_sign_in())
+
+		self.assertIn("--no-first-run", command)
+		self.assertIn("--no-default-browser-check", command)
+
+	def test_it_opens_the_sign_in_page(self):
+		command = signin.browser_command(signin.account_to_sign_in())
+
+		self.assertEqual(command[-1], signin.SIGNIN_URL)
+
+
 @unittest.skipUnless(
 	os.environ.get("REWARDS_BROWSER_TESTS"),
 	"needs Xvfb, x11vnc and websockify; run in the container with "

--- a/tests/test_signin.py
+++ b/tests/test_signin.py
@@ -239,6 +239,35 @@ class TestCleanShutdown(EnvironmentTestCase):
 			process.wait(timeout=30)
 
 
+class TestPublishedPort(unittest.TestCase):
+	"""The compose file is where the exposure is actually decided.
+
+	websockify binds every interface inside the container because docker
+	forwards a published port to the container's address, so nothing in the
+	Python constrains this. Dropping the 127.0.0.1 prefix would put a live
+	Microsoft sign-in on every interface of the host, and would look like
+	tidying up.
+	"""
+
+	def test_the_bridge_is_published_to_loopback_only(self):
+		compose = os.path.join(os.path.dirname(__file__), "..", "docker-compose.yml")
+
+		with open(compose, encoding="utf-8") as handle:
+			entries = [
+				line.strip().lstrip("- ").strip('"')
+				for line in handle
+				if line.strip().startswith("-") and f":{signin.BRIDGE_PORT}" in line
+			]
+
+		self.assertTrue(entries, "nothing publishes the noVNC port at all")
+
+		for entry in entries:
+			self.assertTrue(
+				entry.startswith("127.0.0.1:"),
+				f"{entry!r} publishes the sign-in screen beyond loopback",
+			)
+
+
 class TestLockOwnership(unittest.TestCase):
 	"""A lock this run did not take is not this run's to remove.
 

--- a/tests/test_signin.py
+++ b/tests/test_signin.py
@@ -206,6 +206,60 @@ class TestCleanShutdown(EnvironmentTestCase):
 			"profile as open elsewhere",
 		)
 
+	def test_being_stopped_says_the_sign_in_was_probably_lost(self):
+		"""Silence here cost a working sign-in and four probes chasing it.
+
+		Chromium writes the session on its own shutdown and skips that on the
+		fast exit a signal produces, so a sign-in finished just before a Ctrl-C
+		is gone. The profile looks fine and fails at the next run, which is the
+		worst shape a failure can take.
+		"""
+		process = subprocess.Popen(
+			[sys.executable, SIGNIN_SCRIPT],
+			stdout=subprocess.PIPE,
+			stderr=subprocess.STDOUT,
+			text=True,
+			env=dict(os.environ),
+		)
+		self.addCleanup(self._make_sure_it_is_gone, process)
+
+		self.assertTrue(wait_for(self.lock_exists), "the browser never started")
+
+		process.send_signal(signal.SIGTERM)
+		output, _ = process.communicate(timeout=60)
+
+		self.assertIn("NOT saved", output)
+		self.assertNotIn("sign-in saved to the profile", output)
+
+	def test_a_browser_that_exits_on_its_own_does_not_warn(self):
+		"""The warning has to distinguish, or it is noise on every normal run.
+
+		The browser ending by itself is what closing the window looks like from
+		here, so ending it externally exercises that branch.
+		"""
+		process = subprocess.Popen(
+			[sys.executable, SIGNIN_SCRIPT],
+			stdout=subprocess.PIPE,
+			stderr=subprocess.STDOUT,
+			text=True,
+			env=dict(os.environ),
+		)
+		self.addCleanup(self._make_sure_it_is_gone, process)
+
+		self.assertTrue(wait_for(self.lock_exists), "the browser never started")
+
+		# Past the fast-exit window first. A browser that ends inside it has
+		# refused the profile rather than been closed, which is a different
+		# branch with a different message, and killing it too early tests that
+		# one instead of this one.
+		time.sleep(signin.FAST_EXIT_SECONDS + 1)
+		subprocess.run(["pkill", "-f", "msedge"], check=False)
+
+		output, _ = process.communicate(timeout=60)
+
+		self.assertIn("sign-in saved to the profile", output)
+		self.assertNotIn("NOT saved", output)
+
 	def test_the_profile_can_be_opened_again_afterwards(self):
 		"""The guarantee is a usable profile, not an absent file.
 

--- a/tests/test_signin.py
+++ b/tests/test_signin.py
@@ -1,0 +1,80 @@
+"""Tests for signing a profile in from inside the container.
+
+The sign-in exists because Chromium takes its cookie key from the operating
+system: a profile signed in on a Windows or macOS host cannot be read by the
+container, so the container's own Edge has to write it. That browser needs a
+display, and the display needs to reach the user without anything installed on
+the host.
+
+Most of what can go wrong here is not the browser. It is picking the wrong
+profile directory, publishing the screen somewhere it should not be published,
+and leaving a SingletonLock behind when the browser is killed rather than
+closed, which makes every later run look like the profile is open elsewhere.
+
+	python -m unittest discover -s tests
+	REWARDS_BROWSER_TESTS=1 python -m unittest discover -s tests
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import accounts
+import signin
+from constants import USER_DATA_DIR
+
+
+class EnvironmentTestCase(unittest.TestCase):
+	"""Restores everything these tests reach into, so ordering cannot matter."""
+
+	def setUp(self):
+		self.addCleanup(os.environ.pop, accounts.ENV_VAR, None)
+
+
+class TestAccountSelection(EnvironmentTestCase):
+	"""One browser window, so one account.
+
+	Resolution goes through accounts.configured() rather than reimplementing the
+	name rules, so a name this refuses is exactly a name a run refuses.
+	"""
+
+	def test_unset_is_the_default_profile(self):
+		os.environ.pop(accounts.ENV_VAR, None)
+
+		self.assertEqual(signin.account_to_sign_in().user_data_dir, USER_DATA_DIR)
+
+	def test_one_name_is_that_profile(self):
+		os.environ[accounts.ENV_VAR] = "personal"
+
+		account = signin.account_to_sign_in()
+
+		self.assertEqual(account.name, "personal")
+		self.assertEqual(account.user_data_dir, os.path.join(USER_DATA_DIR, "personal"))
+
+	def test_several_names_are_refused(self):
+		os.environ[accounts.ENV_VAR] = "personal,spare"
+
+		with self.assertRaises(ValueError) as caught:
+			signin.account_to_sign_in()
+
+		# Naming both is the whole value of the message: the reader has to be
+		# able to see what to run instead without going to the source.
+		message = str(caught.exception)
+
+		self.assertIn("personal", message)
+		self.assertIn("spare", message)
+
+	def test_a_name_a_run_would_refuse_is_refused_here_too(self):
+		# "..." is data-dir itself once Win32 strips the trailing dot. If this
+		# resolved, a sign-in would write the default profile under a name that
+		# reads as a separate account.
+		os.environ[accounts.ENV_VAR] = "..."
+
+		with self.assertRaises(ValueError):
+			signin.account_to_sign_in()
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_signin.py
+++ b/tests/test_signin.py
@@ -252,6 +252,12 @@ class TestPublishedPort(unittest.TestCase):
 	def test_the_bridge_is_published_to_loopback_only(self):
 		compose = os.path.join(os.path.dirname(__file__), "..", "docker-compose.yml")
 
+		if not os.path.exists(compose):
+			# The image carries src/ and nouns.txt and no compose file, so this
+			# runs from a checkout. Skipping rather than passing: a test that
+			# quietly finds nothing to check is worse than one that says so.
+			self.skipTest("no docker-compose.yml here; run this from a checkout")
+
 		with open(compose, encoding="utf-8") as handle:
 			entries = [
 				line.strip().lstrip("- ").strip('"')

--- a/tests/test_signin.py
+++ b/tests/test_signin.py
@@ -16,8 +16,13 @@ closed, which makes every later run look like the profile is open elsewhere.
 """
 
 import os
+import shutil
+import signal
 import socket
+import subprocess
 import sys
+import tempfile
+import time
 import unittest
 import urllib.request
 
@@ -28,9 +33,25 @@ import signin
 from constants import USER_DATA_DIR
 
 
+SIGNIN_SCRIPT = os.path.join(os.path.dirname(__file__), "..", "src", "signin.py")
+
+
 def container_address() -> str:
 	"""This container's address on the docker network, not loopback."""
 	return socket.gethostbyname(socket.gethostname())
+
+
+def wait_for(predicate, timeout=60):
+	"""Poll until true, or give up. Returns whether it came true."""
+	deadline = time.monotonic() + timeout
+
+	while time.monotonic() < deadline:
+		if predicate():
+			return True
+
+		time.sleep(0.2)
+
+	return False
 
 
 class EnvironmentTestCase(unittest.TestCase):
@@ -124,6 +145,152 @@ class TestDisplayStack(unittest.TestCase):
 			# vnc.html, and a bare URL 404ing reads as a broken feature.
 			self.assertEqual(response.status, 200)
 			self.assertIn(b"noVNC", body)
+
+
+@unittest.skipUnless(
+	os.environ.get("REWARDS_BROWSER_TESTS"),
+	"starts Edge on a virtual display; run in the container with "
+	"REWARDS_BROWSER_TESTS=1",
+)
+class TestCleanShutdown(EnvironmentTestCase):
+	"""Stopping the container must not poison the profile.
+
+	Chromium writes SingletonLock as a symlink naming the machine and process
+	that hold the profile, and removes it on a clean exit. A browser that is
+	killed leaves it behind, and every later run - container or not - reads that
+	as the profile being open somewhere else and refuses to start, with an error
+	that says nothing about a stale lock.
+
+	So this is the regression test for a failure this feature is in a position
+	to cause, on the path a user takes every time they press Ctrl-C.
+	"""
+
+	def setUp(self):
+		super().setUp()
+
+		os.environ[accounts.ENV_VAR] = "shutdown_probe"
+		self.account = signin.account_to_sign_in()
+		self.addCleanup(shutil.rmtree, self.account.user_data_dir, ignore_errors=True)
+
+	def lock_path(self) -> str:
+		return os.path.join(self.account.user_data_dir, "SingletonLock")
+
+	def lock_exists(self) -> bool:
+		# lexists, not exists: the lock is a symlink to "<host>-<pid>", which
+		# does not resolve to anything. exists() follows it and reports False
+		# for a lock that is very much present, which would make this test pass
+		# without testing anything.
+		return os.path.lexists(self.lock_path())
+
+	def test_sigterm_closes_the_browser_and_leaves_no_lock(self):
+		process = subprocess.Popen(
+			[sys.executable, SIGNIN_SCRIPT],
+			stdout=subprocess.DEVNULL,
+			stderr=subprocess.DEVNULL,
+			env=dict(os.environ),
+		)
+		self.addCleanup(self._make_sure_it_is_gone, process)
+
+		self.assertTrue(
+			wait_for(self.lock_exists), "the browser never took the profile lock"
+		)
+
+		process.send_signal(signal.SIGTERM)
+
+		# Exiting 0 is half the claim: a process that died on the signal would
+		# report -15 and would not have run its shutdown at all.
+		self.assertEqual(process.wait(timeout=60), 0)
+		self.assertFalse(
+			self.lock_exists(),
+			"SingletonLock survived shutdown; every later run will read this "
+			"profile as open elsewhere",
+		)
+
+	def test_the_profile_can_be_opened_again_afterwards(self):
+		"""The guarantee is a usable profile, not an absent file.
+
+		Asserting only that the lock is gone would still pass if shutdown left
+		the profile unopenable some other way, which is the thing a user
+		actually runs into.
+		"""
+		for attempt in ("first", "second"):
+			process = subprocess.Popen(
+				[sys.executable, SIGNIN_SCRIPT],
+				stdout=subprocess.DEVNULL,
+				stderr=subprocess.DEVNULL,
+				env=dict(os.environ),
+			)
+			self.addCleanup(self._make_sure_it_is_gone, process)
+
+			self.assertTrue(
+				wait_for(self.lock_exists),
+				f"the {attempt} run never opened the profile",
+			)
+
+			process.send_signal(signal.SIGTERM)
+
+			# 1 is the exit code for a browser that refused the profile, which
+			# is exactly what a stale lock from the first run would produce.
+			self.assertEqual(process.wait(timeout=60), 0, f"{attempt} run")
+
+	def _make_sure_it_is_gone(self, process):
+		if process.poll() is None:
+			process.kill()
+			process.wait(timeout=30)
+
+
+class TestLockOwnership(unittest.TestCase):
+	"""A lock this run did not take is not this run's to remove.
+
+	The whole reason the lock is honoured is that a profile open on another
+	machine must not be opened twice. Clearing it indiscriminately on shutdown
+	would trade one failure for a worse one.
+	"""
+
+	def setUp(self):
+		self.directory = tempfile.mkdtemp()
+		self.addCleanup(shutil.rmtree, self.directory, ignore_errors=True)
+
+		self.account = accounts.Account(
+			name="probe", user_data_dir=self.directory, profile_name="Default"
+		)
+		self.lock = os.path.join(self.directory, "SingletonLock")
+
+	def write_lock(self, owner):
+		try:
+			os.symlink(owner, self.lock)
+		except (OSError, NotImplementedError) as exc:
+			# Windows refuses symlinks without developer mode or elevation.
+			self.skipTest(f"cannot create a symlink here: {exc}")
+
+	def test_a_lock_from_another_machine_is_left_alone(self):
+		self.write_lock("some-other-host-4321")
+
+		# Says so as well as doing so: a lock left in place without a word looks
+		# identical to one that was never noticed.
+		with self.assertLogs(signin.logger, level="WARNING") as logged:
+			signin._release_profile_lock(self.account, browser_pid=4321)
+
+		self.assertTrue(os.path.lexists(self.lock))
+		self.assertIn("some-other-host-4321", "\n".join(logged.output))
+
+	def test_a_lock_from_another_process_here_is_left_alone(self):
+		self.write_lock(f"{socket.gethostname()}-999999")
+
+		with self.assertLogs(signin.logger, level="WARNING"):
+			signin._release_profile_lock(self.account, browser_pid=4321)
+
+		self.assertTrue(os.path.lexists(self.lock))
+
+	def test_our_own_lock_is_removed(self):
+		self.write_lock(f"{socket.gethostname()}-4321")
+
+		signin._release_profile_lock(self.account, browser_pid=4321)
+
+		self.assertFalse(os.path.lexists(self.lock))
+
+	def test_no_lock_at_all_is_not_an_error(self):
+		signin._release_profile_lock(self.account, browser_pid=4321)
 
 
 if __name__ == "__main__":

--- a/tests/test_signin.py
+++ b/tests/test_signin.py
@@ -16,14 +16,21 @@ closed, which makes every later run look like the profile is open elsewhere.
 """
 
 import os
+import socket
 import sys
 import unittest
+import urllib.request
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 import accounts
 import signin
 from constants import USER_DATA_DIR
+
+
+def container_address() -> str:
+	"""This container's address on the docker network, not loopback."""
+	return socket.gethostbyname(socket.gethostname())
 
 
 class EnvironmentTestCase(unittest.TestCase):
@@ -74,6 +81,49 @@ class TestAccountSelection(EnvironmentTestCase):
 
 		with self.assertRaises(ValueError):
 			signin.account_to_sign_in()
+
+
+@unittest.skipUnless(
+	os.environ.get("REWARDS_BROWSER_TESTS"),
+	"needs Xvfb, x11vnc and websockify; run in the container with "
+	"REWARDS_BROWSER_TESTS=1",
+)
+class TestDisplayStack(unittest.TestCase):
+	"""Where the screen is published, which is the part with a blast radius.
+
+	While a sign-in is open this is a live Microsoft page, so the reachable
+	surface is worth asserting rather than assuming.
+	"""
+
+	def test_the_vnc_server_never_leaves_the_container(self):
+		with signin.display_stack():
+			self.assertTrue(signin.is_listening("127.0.0.1", signin.VNC_PORT))
+			# x11vnc is bound with -localhost, so only websockify in this same
+			# container can reach it. Nothing publishes 5900 and nothing should.
+			self.assertFalse(
+				signin.is_listening(container_address(), signin.VNC_PORT)
+			)
+
+	def test_the_bridge_serves_novnc(self):
+		with signin.display_stack():
+			# The bridge does bind every interface, because docker publishes a
+			# port by forwarding to the container's address: bound to loopback
+			# here it would be unreachable through the published port. The
+			# boundary is the 127.0.0.1 prefix on the compose publish, so the
+			# host only exposes it on its own loopback.
+			self.assertTrue(
+				signin.is_listening(container_address(), signin.BRIDGE_PORT)
+			)
+
+			with urllib.request.urlopen(
+				f"http://127.0.0.1:{signin.BRIDGE_PORT}/", timeout=15
+			) as response:
+				body = response.read()
+
+			# index.html is a symlink the image adds; Debian ships only
+			# vnc.html, and a bare URL 404ing reads as a broken feature.
+			self.assertEqual(response.status, 200)
+			self.assertIn(b"noVNC", body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> **Based on #36.** That branch is the parent, so GitHub shows its commits here as well. The new
> work is the last 12 commits and five files: `src/signin.py`, `tests/test_signin.py`, `Dockerfile`,
> `docker-compose.yml` and the Docker section of the README. Happy to rebase this down once #36
> lands, or to hold it until then.

## The problem

#36 added a Docker path, but signing in had to happen on the host and be carried in on the volume.
That only works when the container can unwrap the profile's cookie key. Chromium takes that key from
the operating system: Windows wraps it with DPAPI tied to the Windows account, macOS with the login
Keychain, and the container can reach neither.

Measured on a Windows host: a profile signed in with a normal Edge window had 73 cookies on disk, of
which Edge in the container could read 19 — the ones it had just set itself. `.MSA.Auth` and `ANON`,
the ones the session actually rests on, came back absent. The container starts, looks healthy and
behaves as though it were logged out.

So the README had to tell a Windows or macOS reader to give up on Docker and run the bot directly.

## What this does

Sign-in happens inside the container, and that browser is served to you as a web page:

```sh
docker compose run --rm --service-ports signin
```

Open <http://localhost:6080>, sign in, close the Edge window on that screen. The container exits on
its own. Nothing is installed on the host.

The profile is written by the same Edge that later reads it, so the two never disagree about the key
and the host operating system stops mattering. Three processes sit behind that page, started in
dependency order and stopped in reverse: `Xvfb` gives the browser a screen, `x11vnc` serves that
screen bound to loopback, `websockify` bridges it to noVNC.

Sign-in itself stays manual. Nothing here reads, stores or types a credential.

## Exposure

`x11vnc` is bound `-localhost` and nothing publishes 5900. `websockify` binds every interface inside
the container because Docker forwards a published port to the container's own address, so the
boundary is the compose publish: `127.0.0.1:6080:6080`. For as long as the service is up that port
is showing a live Microsoft sign-in page, so the prefix is load-bearing rather than decoration, and
a test asserts it stays.

## Verified

Two real Microsoft accounts, each signed in through this flow, then run together:

```sh
REWARDS_ACCOUNTS=acct_a,acct_b docker compose run --rm rewards-farmer
```

`2/2 accounts ran`, exit 0.

|  | acct_a | acct_b |
| --- | --- | --- |
| tier | Silver | Member |
| bing search quota | 25/50 → **30/50** | already 25/25 |

Daily set, Explore on Bing, misc cards and bonus points all `[OK]` on both. acct_a stopped itself
with `Round produced no points, stopping instead of searching pointlessly` rather than grinding.
Visual search skipped on both with `not available in this UI variant`, which is a UI variation
rather than anything new here.

Re-opened afterwards with the bot's own `build_options`, both profiles land on
`rewards.bing.com/dashboard`; a logged-out profile is redirected to `/about`. That is the claim the
feature rests on — a profile written by the container's Edge is readable by the container's Edge.

48 tests pass. The browser-dependent ones are behind a flag, since they need Xvfb, x11vnc and
websockify:

```sh
python -m unittest discover -s tests
REWARDS_BROWSER_TESTS=1 python -m unittest discover -s tests   # in the container
```

They cover where the screen is published, that SIGTERM closes the browser and leaves no
`SingletonLock`, that the profile can be opened again afterwards, and that a lock belonging to
another machine is left alone.

## Two things worth knowing

Signing in signs the browser in, not only the website, so Edge syncs bookmarks and autofill into the
profile it has just created. Harmless — `data-dir` is a bot profile in the project directory and is
gitignored — but the README now says so rather than leaving it to be discovered.

Stopping the container with Ctrl-C or `docker stop` is reported rather than passed over. Chromium
writes the session on its own shutdown and skips that on the fast exit a signal produces, so a
sign-in finished just before a Ctrl-C is simply gone while the profile still looks healthy. That
cost a working sign-in while this was being built, so the signal path now says the sign-in was
probably not saved and what to do instead.
