### PR TITLE
Add mobile app tasks (Read to Earn), lifecycle hardening, and restore…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 Todo.md
 data-dir/
 __pycache__/
+*.pyc
+points_history.json
+points_summary.txt
+src/.bak-*/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,11 @@ requires-python = ">=3.12"
 dependencies = [
     "selenium (>=4.46.0,<5.0.0)",
     "matplotlib (>=3.11.1,<4.0.0)",
-    "pygetwindow (>=0.0.9,<0.0.10)",
-    "keyboard (>=0.13.5,<0.14.0)",
     "pygame-ce (>=2.5.8,<3.0.0)",
-    "ollama (>=0.6.2,<0.7.0)"
+    "ollama (>=0.6.2,<0.7.0)",
+    "pillow (>=10.0.0)",
+    "pygetwindow (>=0.0.9,<0.0.10); sys_platform == 'win32'",
+    "keyboard (>=0.13.5,<0.14.0); sys_platform == 'win32'"
 ]
 
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Microsoft Rewards Farmer — headless daily run.
+# Cron entry (crontab -e): 30 8 * * * cd /home/ellioth/microsoft-rewards/rewards-farmer && ./run.sh >> /home/ellioth/logs/rewards.log 2>&1
+set -euo pipefail
+cd "$(dirname "$0")"
+export PYTHONPATH=src
+
+# --- Pre-flight: make sure the Ollama service is reachable (LLM-assisted queries) ---
+OLLAMA_URL="${OLLAMA_HOST:-http://localhost:11434}"
+if ! curl -fsS --max-time 5 "${OLLAMA_URL}/api/tags" >/dev/null 2>&1; then
+	echo "[INFO] Ollama not responding at ${OLLAMA_URL} — attempting to start user service..."
+	# systemctl --user needs these under cron (no session env there)
+	export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+	export DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=${XDG_RUNTIME_DIR}/bus}"
+	systemctl --user start ollama.service 2>/dev/null \
+		|| sudo -n systemctl start ollama.service 2>/dev/null \
+		|| true
+	for _ in $(seq 1 15); do
+		if curl -fsS --max-time 2 "${OLLAMA_URL}/api/tags" >/dev/null 2>&1; then break; fi
+		sleep 2
+	done
+fi
+if curl -fsS --max-time 5 "${OLLAMA_URL}/api/tags" >/dev/null 2>&1; then
+	if ! curl -fsS --max-time 5 "${OLLAMA_URL}/api/tags" 2>/dev/null | grep -q 'llama3.2'; then
+		echo "[WARNING] Ollama is up but model llama3.2 is missing — run: ollama pull llama3.2"
+	fi
+	echo "[INFO] Ollama pre-flight OK (${OLLAMA_URL})"
+else
+	echo "[WARNING] Ollama still unreachable — farmer continues without LLM-assisted queries."
+fi
+
+exec .venv/bin/python src/main.py --headless

--- a/src/app_rewards.py
+++ b/src/app_rewards.py
@@ -1,0 +1,205 @@
+import time
+import json
+import secrets
+import urllib.parse
+import urllib.request
+from typing import Optional, Tuple
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+
+from constants import (
+	BING_APP_CLIENT_ID,
+	BING_APP_SCOPE,
+	BING_APP_USER_AGENT,
+	START_APP_USER_AGENT,
+	REWARDS_ACTIVITIES_URL,
+	OAUTH_AUTHORIZE_URL,
+	OAUTH_REDIRECT_URL,
+	OAUTH_TOKEN_URL,
+)
+import element_selectors
+
+
+def get_mobile_app_access_token(driver: webdriver.Edge) -> Optional[str]:
+	"""Acquire OAuth access token for Bing / Microsoft Start App using current authenticated browser session."""
+	auth_params = urllib.parse.urlencode({
+		"response_type": "code",
+		"client_id": BING_APP_CLIENT_ID,
+		"redirect_uri": OAUTH_REDIRECT_URL,
+		"scope": BING_APP_SCOPE,
+		"state": secrets.token_hex(16),
+		"access_type": "offline_access",
+	})
+	auth_url = f"{OAUTH_AUTHORIZE_URL}?{auth_params}"
+
+	main_window = driver.current_window_handle
+	driver.switch_to.new_window("tab")
+	code = None
+
+	try:
+		driver.get(auth_url)
+		# Wait up to 12 seconds for redirection to oauth20_desktop.srf
+		for _ in range(24):
+			curr = driver.current_url
+			if "oauth20_desktop.srf" in curr and "code=" in curr:
+				parsed = urllib.parse.urlparse(curr)
+				qs = urllib.parse.parse_qs(parsed.query)
+				code = qs.get("code", [None])[0]
+				break
+			time.sleep(0.5)
+	except Exception as exc:
+		print(f"[WARNING] Could not navigate to mobile OAuth endpoint: {exc}")
+	finally:
+		try:
+			driver.close()
+		except Exception:
+			pass
+		driver.switch_to.window(main_window)
+
+	if not code:
+		print("[INFO] Mobile OAuth code not resolved (session may need prompt or 2FA).")
+		return None
+
+	# Exchange authorization code for access token
+	try:
+		token_payload = urllib.parse.urlencode({
+			"grant_type": "authorization_code",
+			"client_id": BING_APP_CLIENT_ID,
+			"code": code,
+			"redirect_uri": OAUTH_REDIRECT_URL,
+			"scope": BING_APP_SCOPE,
+		}).encode("utf-8")
+
+		req = urllib.request.Request(
+			OAUTH_TOKEN_URL,
+			data=token_payload,
+			headers={
+				"Content-Type": "application/x-www-form-urlencoded",
+				"User-Agent": BING_APP_USER_AGENT,
+			}
+		)
+		with urllib.request.urlopen(req, timeout=15) as response:
+			data = json.loads(response.read().decode("utf-8"))
+			token = data.get("access_token")
+			if token:
+				print("[INFO] Successfully obtained Bing Mobile App access token.")
+				return token
+	except Exception as exc:
+		print(f"[WARNING] Token exchange error: {exc}")
+
+	return None
+
+
+def execute_read_to_earn_api(access_token: str, max_articles: int = 10) -> int:
+	"""Execute Read to Earn API calls (+3 points per article, up to 30 points)."""
+	print(f"[INFO] Starting Read to Earn API tasks (up to {max_articles} articles)...")
+	articles_read = 0
+	last_balance = None
+
+	for i in range(1, max_articles + 1):
+		item_id = secrets.token_hex(32)
+		payload = json.dumps({
+			"amount": 1,
+			"id": item_id,
+			"type": 101,
+			"attributes": {
+				"offerid": "ENUS_readarticle3_30points"
+			}
+		}).encode("utf-8")
+
+		req = urllib.request.Request(
+			REWARDS_ACTIVITIES_URL,
+			data=payload,
+			headers={
+				"Authorization": f"Bearer {access_token}",
+				"User-Agent": BING_APP_USER_AGENT,
+				"Content-Type": "application/json",
+				"X-Rewards-ismobile": "true",
+			}
+		)
+
+		try:
+			with urllib.request.urlopen(req, timeout=15) as resp:
+				res_data = json.loads(resp.read().decode("utf-8"))
+				curr_balance = res_data.get("response", {}).get("balance")
+
+				if last_balance is not None and curr_balance is not None and curr_balance <= last_balance:
+					print(f"[INFO] Article [{i}/{max_articles}]: Daily read quota reached (balance {curr_balance} pts).")
+					break
+
+				last_balance = curr_balance
+				articles_read += 1
+				balance_str = f" (balance: {curr_balance} pts)" if curr_balance else ""
+				print(f"[INFO] Article [{i}/{max_articles}] read (+3 pts){balance_str}")
+
+		except Exception as exc:
+			print(f"[WARNING] Read to earn error on article {i}: {exc}")
+			break
+
+		# Natural reading delay between articles
+		time.sleep(4.5 + (secrets.randbelow(30) / 10.0))
+
+	return articles_read
+
+
+def execute_daily_checkin_api(access_token: str) -> bool:
+	"""Execute Mobile App Daily Check-In API call (+5 to +25 points)."""
+	item_id = secrets.token_hex(16)
+	payload = json.dumps({
+		"risk_context": {},
+		"type": 103,
+		"channel": "SAIOS",
+		"attributes": {},
+		"id": item_id,
+		"amount": 1,
+	}).encode("utf-8")
+
+	req = urllib.request.Request(
+		REWARDS_ACTIVITIES_URL,
+		data=payload,
+		headers={
+			"Authorization": f"Bearer {access_token}",
+			"User-Agent": START_APP_USER_AGENT,
+			"Content-Type": "application/json",
+			"X-Rewards-AppId": "SAIOS/33.4.440603001",
+			"X-Rewards-PartnerId": "startapp",
+			"X-Rewards-IsMobile": "true",
+		}
+	)
+
+	try:
+		with urllib.request.urlopen(req, timeout=15) as resp:
+			res_data = json.loads(resp.read().decode("utf-8"))
+			curr_balance = res_data.get("response", {}).get("balance")
+			balance_str = f" (balance: {curr_balance} pts)" if curr_balance else ""
+			print(f"[INFO] Mobile App Daily Check-In complete{balance_str}")
+			return True
+	except Exception as exc:
+		print(f"[INFO] Mobile App Daily Check-In not applicable or already claimed today ({exc}).")
+		return False
+
+
+def browse_msn_news_fallback(driver: webdriver.Edge, count: int = 5):
+	"""Fallback: Open MSN News in mobile viewport, scroll headlines and view comments."""
+	print(f"[INFO] Running browser MSN News reading fallback ({count} articles)...")
+	driver.get("https://www.msn.com/en-us/news")
+	element_selectors.dismiss_cookie_and_consent_banners(driver)
+	time.sleep(3.0)
+
+	try:
+		articles = driver.find_elements(By.CSS_SELECTOR, "a[href*='/news/'], a[href*='/article/']")
+		valid_links = [a.get_attribute("href") for a in articles if a.get_attribute("href") and "http" in a.get_attribute("href")]
+		unique_links = list(dict.fromkeys(valid_links))[:count]
+
+		for i, link in enumerate(unique_links, start=1):
+			print(f"[INFO] Reading news article [{i}/{len(unique_links)}]...")
+			driver.get(link)
+			element_selectors.dismiss_cookie_and_consent_banners(driver)
+			time.sleep(2.0)
+			# Natural human scrolling
+			driver.execute_script("window.scrollBy(0, 450);")
+			time.sleep(3.0)
+			driver.execute_script("window.scrollBy(0, 500);")
+			time.sleep(2.5)
+	except Exception as exc:
+		print(f"[WARNING] MSN News fallback browsing encountered error: {exc}")

--- a/src/browser_lifecycle.py
+++ b/src/browser_lifecycle.py
@@ -1,0 +1,337 @@
+import os
+import sys
+import time
+import signal
+import atexit
+import subprocess
+import glob
+from pathlib import Path
+from typing import Optional
+
+from selenium import webdriver
+
+from constants import USER_DATA_DIR, PROFILE_NAME
+
+
+# Singleton files created by Chromium/Edge
+CHROMIUM_LOCK_FILES = (
+	"SingletonLock",
+	"SingletonCookie",
+	"SingletonSocket",
+	"parent_unfreeze_signal",
+)
+
+
+def kill_orphaned_drivers(user_data_dir: Optional[str] = None):
+	"""Gracefully terminate lingering msedgedriver and profile-specific Edge processes.
+	
+	Safety guarantee: Only terminates processes matching 'msedgedriver' or Edge processes
+	specifically running with the automation '--user-data-dir' path. Does NOT touch standard
+	user browser sessions.
+	"""
+	target_dir = os.path.abspath(user_data_dir or USER_DATA_DIR)
+	
+	try:
+		# Query running processes on macOS / Unix
+		ps_output = subprocess.check_output(
+			["ps", "-eo", "pid,command"],
+			text=True,
+			stderr=subprocess.DEVNULL
+		)
+	except Exception as exc:
+		print(f"[DEBUG] Could not query processes via ps: {exc}")
+		return
+
+	pids_to_terminate = []
+
+	for line in ps_output.splitlines():
+		line = line.strip()
+		if not line:
+			continue
+		parts = line.split(maxsplit=1)
+		if len(parts) < 2:
+			continue
+		pid_str, cmd = parts[0], parts[1]
+		
+		try:
+			pid = int(pid_str)
+		except ValueError:
+			continue
+			
+		# Do not target current process
+		if pid == os.getpid():
+			continue
+
+		# Target 1: Orphaned msedgedriver instances
+		if "msedgedriver" in cmd:
+			pids_to_terminate.append((pid, "msedgedriver"))
+			continue
+
+		# Target 2: Edge browser processes bound specifically to our custom user data dir
+		if ("Microsoft Edge" in cmd or "msedge" in cmd) and f"--user-data-dir={target_dir}" in cmd:
+			pids_to_terminate.append((pid, f"Edge (data-dir: {target_dir})"))
+
+	if not pids_to_terminate:
+		return
+
+	print(f"[INFO] Cleaning up {len(pids_to_terminate)} orphaned driver/browser processes...")
+
+	for pid, proc_desc in pids_to_terminate:
+		try:
+			os.kill(pid, signal.SIGTERM)
+		except ProcessLookupError:
+			pass
+		except Exception as exc:
+			print(f"[WARNING] Failed to send SIGTERM to PID {pid} ({proc_desc}): {exc}")
+
+	# Give processes a brief moment to exit cleanly
+	time.sleep(0.5)
+
+	# Escalate to SIGKILL for any stubborn survivors
+	for pid, proc_desc in pids_to_terminate:
+		try:
+			# Check if process is still alive (signal 0 raises if process is gone)
+			os.kill(pid, 0)
+			os.kill(pid, signal.SIGKILL)
+			print(f"[INFO] Force killed lingering process PID {pid} ({proc_desc})")
+		except ProcessLookupError:
+			pass
+		except Exception:
+			pass
+
+
+def cleanup_stale_locks(user_data_dir: Optional[str] = None):
+	"""Remove stale Chromium lock files and symlinks that prevent session startup.
+	
+	Purges SingletonLock, SingletonCookie, SingletonSocket, and LevelDB LOCK files
+	in the target profile directory.
+	"""
+	data_path = Path(user_data_dir or USER_DATA_DIR).resolve()
+	if not data_path.exists():
+		return
+
+	# 1. Clean root Singleton lock files / symlinks
+	for lock_name in CHROMIUM_LOCK_FILES:
+		lock_path = data_path / lock_name
+		try:
+			if lock_path.is_symlink() or lock_path.exists():
+				if lock_path.is_dir() and not lock_path.is_symlink():
+					import shutil
+					shutil.rmtree(lock_path, ignore_errors=True)
+				else:
+					lock_path.unlink(missing_ok=True)
+				print(f"[INFO] Purged stale Chromium lock: {lock_path.name}")
+		except Exception as exc:
+			print(f"[WARNING] Could not remove lock file {lock_path}: {exc}")
+
+	# 2. Clean LevelDB LOCK files in profile directories if present
+	profile_dirs = [data_path / PROFILE_NAME, data_path / "Default", data_path]
+	for p_dir in profile_dirs:
+		if not p_dir.exists():
+			continue
+		for lock_file in p_dir.glob("**/LOCK"):
+			try:
+				if lock_file.is_file() or lock_file.is_symlink():
+					lock_file.unlink(missing_ok=True)
+			except Exception:
+				pass
+
+
+def create_stealth_driver(
+	user_data_dir: Optional[str] = None,
+	profile_name: Optional[str] = None,
+	headless: bool = False,
+	mobile: bool = False,
+) -> webdriver.Edge:
+	"""Pre-flights environment, cleans stale locks, and constructs a stealth Edge WebDriver.
+	
+	Includes Linux server stability flags (--disable-dev-shm-usage), Windows User-Agent spoofing,
+	and CDP hooks to mask headless signatures, navigator.webdriver, and WebGL SwiftShader.
+	"""
+	from constants import WINDOWS_DESKTOP_UA, MOBILE_UA
+
+	target_data_dir = os.path.abspath(user_data_dir or USER_DATA_DIR)
+	target_profile = profile_name or PROFILE_NAME
+
+	# Pre-flight cleanup
+	kill_orphaned_drivers(target_data_dir)
+	cleanup_stale_locks(target_data_dir)
+
+	options = webdriver.EdgeOptions()
+
+	# Anti-detection flags
+	options.add_experimental_option("excludeSwitches", ["enable-automation", "enable-logging"])
+	options.add_experimental_option("useAutomationExtension", False)
+	options.add_argument("--disable-blink-features=AutomationControlled")
+	
+	# Stability & stealth arguments (Critical for Linux Ubuntu Server & container stability)
+	options.add_argument("--disable-dev-shm-usage")
+	options.add_argument("--no-first-run")
+	options.add_argument("--no-default-browser-check")
+	options.add_argument("--disable-infobars")
+	options.add_argument("--disable-notifications")
+	options.add_argument("--disable-features=Translate,OptimizationHints,MediaRouter")
+	options.add_argument("--disable-default-apps")
+	options.add_argument("--disable-component-update")
+	
+	# User-Agent & Window sizing
+	if mobile:
+		options.add_argument(f"--user-agent={MOBILE_UA}")
+		options.add_argument("--window-size=393,852")
+	else:
+		# Spoof Windows 10/11 Edge User-Agent on Linux server
+		options.add_argument(f"--user-agent={WINDOWS_DESKTOP_UA}")
+		options.add_argument("--window-size=1366,768")
+		options.add_argument("--start-maximized")
+
+	# Profile isolation
+	options.add_argument(f"--user-data-dir={target_data_dir}")
+	options.add_argument(f"--profile-directory={target_profile}")
+
+	if headless:
+		options.add_argument("--headless=new")
+
+	def apply_stealth_cdp_hooks(drv: webdriver.Edge):
+		"""Inject CDP scripts to mask webdriver flag, SwiftShader GPU, and chrome runtime."""
+		stealth_script = """
+		// 1. Mask navigator.webdriver
+		Object.defineProperty(navigator, 'webdriver', {
+			get: () => undefined,
+			configurable: true
+		});
+
+		// 2. Mask WebGL vendor and renderer (hides Google SwiftShader / llvmpipe on headless Linux servers)
+		const maskWebGL = (proto) => {
+			if (!proto) return;
+			const origGetParameter = proto.getParameter;
+			proto.getParameter = function(param) {
+				// UNMASKED_VENDOR_WEBGL
+				if (param === 37445) return 'Intel Inc.';
+				// UNMASKED_RENDERER_WEBGL
+				if (param === 37446) return 'Intel(R) UHD Graphics 630';
+				return origGetParameter.apply(this, arguments);
+			};
+		};
+		try {
+			if (typeof WebGLRenderingContext !== 'undefined') maskWebGL(WebGLRenderingContext.prototype);
+			if (typeof WebGL2RenderingContext !== 'undefined') maskWebGL(WebGL2RenderingContext.prototype);
+		} catch (e) {}
+
+		// 3. Ensure window.chrome runtime object exists in headless
+		if (!window.chrome) {
+			window.chrome = {};
+		}
+		if (!window.chrome.runtime) {
+			window.chrome.runtime = {
+				PlatformOs: { MAC: 'mac', WIN: 'win', ANDROID: 'android', CROS: 'cros', LINUX: 'linux' }
+			};
+		}
+
+		// 4. Ensure plugins array looks authentic
+		if (!navigator.plugins || navigator.plugins.length === 0) {
+			Object.defineProperty(navigator, 'plugins', {
+				get: () => [1, 2, 3, 4, 5],
+				configurable: true
+			});
+		}
+		"""
+		try:
+			drv.execute_cdp_cmd("Page.addScriptToEvaluateOnNewDocument", {"source": stealth_script})
+		except Exception as exc:
+			print(f"[DEBUG] Could not inject stealth CDP script: {exc}")
+
+		# Set focus on protocol level
+		try:
+			drv.execute_cdp_cmd("Emulation.setFocusEmulationEnabled", {"enabled": True})
+		except Exception:
+			pass
+
+	try:
+		driver = webdriver.Edge(options=options)
+		apply_stealth_cdp_hooks(driver)
+	except Exception as exc:
+		# If session failed, attempt emergency lock purge and retry once
+		print(f"[WARNING] WebDriver creation failed ({exc}). Retrying after emergency lock purge...")
+		kill_orphaned_drivers(target_data_dir)
+		cleanup_stale_locks(target_data_dir)
+		time.sleep(1.0)
+		driver = webdriver.Edge(options=options)
+		apply_stealth_cdp_hooks(driver)
+
+	return driver
+
+
+class BrowserManager:
+	"""Context manager for reliable browser lifecycle, signal handling, and clean teardown."""
+
+	def __init__(
+		self,
+		user_data_dir: Optional[str] = None,
+		profile_name: Optional[str] = None,
+		headless: bool = False,
+		mobile: bool = False,
+	):
+		self.user_data_dir = os.path.abspath(user_data_dir or USER_DATA_DIR)
+		self.profile_name = profile_name or PROFILE_NAME
+		self.headless = headless
+		self.mobile = mobile
+		self.driver: Optional[webdriver.Edge] = None
+		self._original_sigint = None
+		self._original_sigterm = None
+		self._cleaned_up = False
+
+	def __enter__(self) -> webdriver.Edge:
+		self._setup_signal_handlers()
+		self.driver = create_stealth_driver(
+			user_data_dir=self.user_data_dir,
+			profile_name=self.profile_name,
+			headless=self.headless,
+			mobile=self.mobile,
+		)
+		atexit.register(self.cleanup)
+		return self.driver
+
+	def __exit__(self, exc_type, exc_val, exc_tb):
+		self.cleanup()
+		self._restore_signal_handlers()
+		return False
+
+	def _setup_signal_handlers(self):
+		def handle_signal(signum, frame):
+			sig_name = "SIGINT" if signum == signal.SIGINT else "SIGTERM"
+			print(f"\n[INFO] Intercepted {sig_name}. Gracefully terminating browser...")
+			self.cleanup()
+			sys.exit(130 if signum == signal.SIGINT else 143)
+
+		try:
+			self._original_sigint = signal.signal(signal.SIGINT, handle_signal)
+			self._original_sigterm = signal.signal(signal.SIGTERM, handle_signal)
+		except (ValueError, AttributeError):
+			# Not in main thread or platform does not support signal
+			pass
+
+	def _restore_signal_handlers(self):
+		try:
+			if self._original_sigint is not None:
+				signal.signal(signal.SIGINT, self._original_sigint)
+			if self._original_sigterm is not None:
+				signal.signal(signal.SIGTERM, self._original_sigterm)
+		except (ValueError, AttributeError):
+			pass
+
+	def cleanup(self):
+		if self._cleaned_up:
+			return
+		self._cleaned_up = True
+
+		if self.driver:
+			try:
+				print("[INFO] Closing browser session...")
+				self.driver.quit()
+			except Exception as exc:
+				print(f"[DEBUG] Error during driver.quit(): {exc}")
+			finally:
+				self.driver = None
+
+		# Post-session lock cleanup
+		cleanup_stale_locks(self.user_data_dir)

--- a/src/check_selectors.py
+++ b/src/check_selectors.py
@@ -16,25 +16,13 @@ variant does not ship. FAILED is what needs fixing.
 import sys
 import time
 
-from selenium import webdriver
 from selenium.webdriver.common.by import By
 
 import element_selectors
+from browser_lifecycle import BrowserManager
 from constants import USER_DATA_DIR, PROFILE_NAME
 
-RENDER_TIMEOUT = 60
-
-
-def build_driver():
-	options = webdriver.EdgeOptions()
-
-	options.add_experimental_option("excludeSwitches", ["enable-automation"])
-	options.add_experimental_option("useAutomationExtension", False)
-	options.add_argument("--disable-blink-features=AutomationControlled")
-	options.add_argument(f"--user-data-dir={USER_DATA_DIR}")
-	options.add_argument(f"--profile-directory={PROFILE_NAME}")
-
-	return webdriver.Edge(options=options)
+RENDER_TIMEOUT = 45
 
 
 def wait_until(predicate, timeout=RENDER_TIMEOUT):
@@ -47,7 +35,7 @@ def wait_until(predicate, timeout=RENDER_TIMEOUT):
 		except Exception:
 			pass
 
-		time.sleep(2)
+		time.sleep(1.5)
 
 	return False
 
@@ -119,20 +107,24 @@ def describe_environment(driver, report):
 
 
 def main():
-	driver = build_driver()
-	elements = element_selectors.ElementSelectionUtils(driver)
 	report = Report()
 
-	try:
+	with BrowserManager(user_data_dir=USER_DATA_DIR, profile_name=PROFILE_NAME) as driver:
+		elements = element_selectors.ElementSelectionUtils(driver)
+
 		driver.get("https://rewards.bing.com/earn")
+		element_selectors.dismiss_cookie_and_consent_banners(driver)
 
 		rendered = wait_until(lambda: elements.get_points_breakdown_button() is not None)
 
 		if not rendered:
+			# Retry dismissal once more if blocking
+			element_selectors.dismiss_cookie_and_consent_banners(driver)
+			rendered = wait_until(lambda: elements.get_points_breakdown_button() is not None, 15)
+
+		if not rendered:
 			print("The earn page never finished rendering.")
-			print("In the EU the cookie consent banner blocks it until answered, and it")
-			print("cannot be dismissed reliably from selenium. Open the profile in a")
-			print("normal Edge window, answer the banner once, then run this again.")
+			print("Please verify the network connection or answer any interactive prompt once.")
 			return 2
 
 		describe_environment(driver, report)
@@ -180,17 +172,11 @@ def main():
 
 		print("\n## points breakdown")
 		driver.get("https://rewards.bing.com/earn")
+		element_selectors.dismiss_cookie_and_consent_banners(driver)
 		wait_until(lambda: elements.get_points_breakdown_button() is not None)
 		driver.execute_script("arguments[0].click();", elements.get_points_breakdown_button())
 		wait_until(lambda: elements.get_sidebar_section() is not None, 30)
 
-		# The section exists before it has content: the panel renders a
-		# "Loading..." placeholder inside it first, and that satisfies the
-		# presence check above immediately. Waiting only for the section leaves
-		# the two selectors below reading an empty panel, so they report FAILED
-		# for markup that is fine, on a page that is merely slow. Wait for the
-		# content itself. A selector that really is broken still reports FAILED,
-		# it just costs the timeout first.
 		wait_until(
 			lambda: elements.get_points_earned_from_searches_on_points_breakdown() is not None,
 			30,
@@ -205,11 +191,13 @@ def main():
 
 		print("\n## bonus")
 		driver.get("https://rewards.bing.com/dashboard")
+		element_selectors.dismiss_cookie_and_consent_banners(driver)
 		wait_until(lambda: elements.get_bonus_button_on_dashboard() is not None, 30)
 		report.check("get_bonus_button_on_dashboard", elements.get_bonus_button_on_dashboard, optional=True)
 
 		print("\n## bing")
 		driver.get("https://www.bing.com/")
+		element_selectors.dismiss_cookie_and_consent_banners(driver)
 		wait_until(lambda: bool(driver.find_elements(By.TAG_NAME, "textarea")), 30)
 		report.check("get_bing_search_bar", elements.get_bing_search_bar)
 
@@ -221,8 +209,6 @@ def main():
 			print("\nEvery selector that this variant ships resolved.")
 
 		return 1 if failures else 0
-	finally:
-		driver.quit()
 
 
 if __name__ == "__main__":

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,4 +1,73 @@
-from os.path import abspath
+import os
+from pathlib import Path
 
-USER_DATA_DIR = abspath("./data-dir")
-PROFILE_NAME = "Default"
+# Project root path
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# Browser & Profile paths
+USER_DATA_DIR = os.environ.get("REWARDS_USER_DATA_DIR", str(PROJECT_ROOT / "data-dir"))
+PROFILE_NAME = os.environ.get("REWARDS_PROFILE_NAME", "Default")
+VISUAL_SEARCH_IMAGE_PATH = PROJECT_ROOT / "visual_search.jpg"
+
+# URLs
+BING_BASE_URL = "https://www.bing.com/"
+REWARDS_EARN_URL = "https://rewards.bing.com/earn"
+REWARDS_DASHBOARD_URL = "https://rewards.bing.com/dashboard"
+
+# Desktop & Mobile User Agents (Windows Edge spoofing on Linux)
+WINDOWS_DESKTOP_UA = (
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+	"AppleWebKit/537.36 (KHTML, like Gecko) "
+	"Chrome/125.0.0.0 Safari/537.36 Edg/125.0.0.0"
+)
+MOBILE_UA = (
+	"Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) "
+	"AppleWebKit/605.1.15 (KHTML, like Gecko) "
+	"Version/17.5 Mobile/15E148 Safari/604.1 Edg/125.0.0.0"
+)
+
+# Ollama & LLM settings
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+DEFAULT_MODEL = os.environ.get("OLLAMA_MODEL", "llama3.2")
+MODEL_FALLBACK_PREFERENCES = (
+	"llama3.2",
+	"llama3.2:3b",
+	"llama3.2:1b",
+	"llama3.1",
+	"llama3.1:8b",
+	"llama3",
+	"mistral",
+	"phi3",
+	"phi3.5",
+	"gemma2",
+	"qwen2.5",
+	"qwen2",
+	"tinyllama"
+)
+
+# Human timing / delays (seconds)
+IDLE_DELAY_MIN = 2.5
+IDLE_DELAY_MAX = 6.0
+MICRO_DELAY_MIN = 0.4
+MICRO_DELAY_MAX = 1.2
+TASK_PAUSE_MIN = 3.0
+TASK_PAUSE_MAX = 7.5
+
+# Search Cooldown Settings (Microsoft 15-minute search throttling)
+COOLDOWN_BATCH_SIZE = 4
+COOLDOWN_SEARCH_DELAY_MIN = 10.0
+COOLDOWN_SEARCH_DELAY_MAX = 20.0
+COOLDOWN_SLEEP_MIN = 15.5 * 60  # 15.5 minutes in seconds
+COOLDOWN_SLEEP_MAX = 17.5 * 60  # 17.5 minutes in seconds
+MAX_COOLDOWN_ROUNDS = 6
+MAX_TOTAL_RUNTIME_SECONDS = 110 * 60  # 110 min safety cut-off
+
+# Bing / Start Mobile App API settings (Read to Earn & Daily Check-In)
+BING_APP_CLIENT_ID = "0000000040170455"
+BING_APP_SCOPE = "service::prod.rewardsplatform.microsoft.com::MBI_SSL"
+BING_APP_USER_AGENT = "Bing/32.5.431027001 (com.microsoft.bing; build:431027001; iOS 17.6.1) Alamofire/5.10.2"
+START_APP_USER_AGENT = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Mobile/15E148 Safari/605.1.15 BingSapphire/33.4.440603001"
+REWARDS_ACTIVITIES_URL = "https://prod.rewardsplatform.microsoft.com/dapi/me/activities"
+OAUTH_AUTHORIZE_URL = "https://login.live.com/oauth20_authorize.srf"
+OAUTH_REDIRECT_URL = "https://login.live.com/oauth20_desktop.srf"
+OAUTH_TOKEN_URL = "https://login.microsoftonline.com/consumers/oauth2/v2.0/token"

--- a/src/element_selectors.py
+++ b/src/element_selectors.py
@@ -1,76 +1,248 @@
 import re
+from typing import Union, Sequence, Optional, List, Tuple
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
-from selenium.common.exceptions import NoSuchElementException, StaleElementReferenceException
+from selenium.common.exceptions import NoSuchElementException, StaleElementReferenceException, WebDriverException
 from selenium import webdriver
 
 
 class Labels:
-	"""Visible labels the selectors match on.
+	"""Multilingual labels the selectors match on.
 
-	The Rewards markup carries no stable hooks for these controls, so they have
-	to be found by their text. That makes the lookups language dependent even
-	though they are market independent: a Rewards UI rendered in another
-	language needs these translated, and there is exactly one place to do it.
-
-	Matching is case insensitive and by substring unless noted.
+	The Rewards markup carries no static IDs for several controls, so they are
+	discovered via visible labels and accessibility attributes. Multilingual
+	tuples support Swedish, English, German, French, Spanish, and Italian variants.
 	"""
 
-	POINTS_BREAKDOWN = "points breakdown"
-	READY_TO_CLAIM = "ready to claim"
-	CLAIM = "claim"                      # exact label preferred, substring as fallback
-	DAILY_SET_STREAK = "daily set streak"
-	CARD_COMPLETED = "completed"
-	# The full streak label on purpose: plain "visual search" also matches an
-	# element on the dashboard, which can go stale mid-interaction.
-	VISUAL_SEARCH_STREAK = "visual search streak"
+	POINTS_BREAKDOWN = (
+		"points breakdown",
+		"poänguppdelning",
+		"poängöversikt",
+		"poänginformation",
+		"punkteübersicht",
+		"desglose de puntos",
+		"détail des points",
+		"dettaglio punti"
+	)
+	
+	READY_TO_CLAIM = (
+		"ready to claim",
+		"redo att göra anspråk",
+		"redo att göra anspråk på",
+		"redo att hämta",
+		"hämta",
+		"gör anspråk",
+		"bereit zum einlösen",
+		"listo para canjear",
+		"prêt à réclamer",
+		"pronto per il riscatto"
+	)
+	
+	CLAIM = (
+		"claim",
+		"hämta",
+		"gör anspråk",
+		"einlösen",
+		"lösa in",
+		"canjear",
+		"réclamer",
+		"riscatta"
+	)
+	
+	DAILY_SET_STREAK = (
+		"daily set streak",
+		"dagligt set-svit",
+		"daglig uppsättning",
+		"dagligt set",
+		"tägliches set",
+		"serie diaria",
+		"série quotidienne",
+		"serie giornaliera"
+	)
+	
+	CARD_COMPLETED = (
+		"completed",
+		"slutförd",
+		"slutfört",
+		"klar",
+		"klart",
+		"avslutad",
+		"avslutat",
+		"abgeschlossen",
+		"completado",
+		"terminé",
+		"completato"
+	)
+	
+	VISUAL_SEARCH_STREAK = (
+		"visual search streak",
+		"visuell sökning",
+		"visuell sök-svit",
+		"visuelle suche",
+		"búsqueda visual",
+		"recherche visuelle",
+		"ricerca visiva"
+	)
+	
+	SEARCH_NOW = (
+		"search now",
+		"sök nu",
+		"jetzt suchen",
+		"buscar ahora",
+		"rechercher maintenant",
+		"cerca ora"
+	)
+
+
+def dismiss_cookie_and_consent_banners(driver: webdriver.Edge) -> int:
+	"""Detect and dismiss localized cookie consent dialogs, sign-in toasts, and promo overlays.
+
+	Returns the count of dismissed overlays. Executes rapidly with zero latency if no
+	dialog is present.
+	"""
+	dismissed_count = 0
+
+	# 1. Fast JS inspection & dismissal for standard Bing consent IDs
+	bing_cookie_js = """
+	let clicked = 0;
+	// Direct standard Bing cookie buttons
+	const directButtons = [
+		document.getElementById('bnp_btn_accept'),
+		document.getElementById('bnp_btn_reject'),
+		document.querySelector('#bnp_container button'),
+		document.querySelector('.bnp_btn'),
+		document.querySelector('#id_d button')
+	];
+	for (const btn of directButtons) {
+		if (btn && btn.offsetParent !== null) {
+			btn.click();
+			clicked++;
+			break;
+		}
+	}
+	return clicked;
+	"""
+	try:
+		if driver.execute_script(bing_cookie_js):
+			dismissed_count += 1
+			print("[INFO] Dismissed Bing cookie banner via direct button.")
+			return dismissed_count
+	except Exception:
+		pass
+
+	# 2. Text-based consent button matching (Swedish, English, European languages)
+	consent_phrases = (
+		"godkänn alla", "acceptera alla", "jag godkänner", "godkänn", "acceptera",
+		"accept all", "i accept", "accept cookies", "accept", "allow all", "i agree",
+		"alle akzeptieren", "akzeptieren", "zustimmen",
+		"aceptar todo", "aceptar", "accepter tout", "accepter", "accetta tutti"
+	)
+
+	# Search buttons inside container or body
+	try:
+		candidate_buttons = driver.find_elements(By.CSS_SELECTOR, "#bnp_container button, #id_d button, [role='dialog'] button, button.bnp_btn")
+		if not candidate_buttons:
+			candidate_buttons = driver.find_elements(By.TAG_NAME, "button")[:15]
+
+		for btn in candidate_buttons:
+			try:
+				if not btn.is_displayed():
+					continue
+				btn_text = (btn.text or btn.get_attribute("aria-label") or "").strip().lower()
+				for phrase in consent_phrases:
+					if phrase in btn_text:
+						driver.execute_script("arguments[0].click();", btn)
+						dismissed_count += 1
+						print(f"[INFO] Dismissed cookie/consent dialog (matched: '{phrase}').")
+						return dismissed_count
+			except StaleElementReferenceException:
+				continue
+	except Exception:
+		pass
+
+	# 3. Dismiss secondary sign-in prompts & toast overlays ("Not now", "Nej tack", "Maybe later")
+	dismiss_phrases = (
+		"not now", "nej tack", "kanske senare", "senare", "maybe later",
+		"no thanks", "nein danke", "avvisa", "stäng"
+	)
+	try:
+		toasts = driver.find_elements(By.CSS_SELECTOR, "div[role='dialog'] button, div[role='alertdialog'] button, .modal button")
+		for btn in toasts:
+			try:
+				if not btn.is_displayed():
+					continue
+				btn_text = (btn.text or btn.get_attribute("aria-label") or "").strip().lower()
+				# Avoid clicking "learn more" links
+				if "learn more" in btn_text or "läs mer" in btn_text:
+					continue
+				if any(p in btn_text for p in dismiss_phrases):
+					driver.execute_script("arguments[0].click();", btn)
+					dismissed_count += 1
+					print(f"[INFO] Dismissed toast/overlay button ('{btn_text}').")
+					break
+			except StaleElementReferenceException:
+				continue
+	except Exception:
+		pass
+
+	# 4. Auto-accept Microsoft 'Stay signed in?' (KMSI) prompt if already authenticated
+	try:
+		current_url = driver.current_url.lower()
+		if "login.live.com" in current_url or "login.microsoftonline.com" in current_url:
+			# Check "Don't show this again" checkbox
+			checkboxes = driver.find_elements(By.CSS_SELECTOR, "#KmsiCheckboxField, input[name='DontShowAgain']")
+			if checkboxes and not checkboxes[0].is_selected():
+				try:
+					driver.execute_script("arguments[0].click();", checkboxes[0])
+				except Exception:
+					pass
+
+			# Click "Yes" / "Accept" button
+			kmsi_buttons = driver.find_elements(By.CSS_SELECTOR, "input#acceptButton, button#acceptButton, input#idSIButton9, input[type='submit'][value*='Yes' i], input[type='submit'][value*='Ja' i]")
+			for k_btn in kmsi_buttons:
+				if k_btn.is_displayed():
+					driver.execute_script("arguments[0].click();", k_btn)
+					dismissed_count += 1
+					print("[INFO] Auto-confirmed Microsoft 'Stay signed in' (Yes).")
+					break
+	except Exception:
+		pass
+
+	return dismissed_count
 
 
 class ElementSelectionUtils:
-	"""Selectors for the Rewards UI.
-
-	These are deliberately semantic rather than positional. The Rewards page is
-	server-rendered React whose markup differs between markets and changes
-	between deploys, so absolute XPaths like
-	`/html/body/div[2]/div[2]/div/main/section[1]/...` resolve to nothing
-	outside the exact variant they were written against.
-
-	Two concrete cases this has to survive:
-
-	1. Outside en-US the page can render an extra `exploreonbing` section, which
-	   shifts every positional section index by one.
-	2. Some sections are emitted twice for responsive layout. The first match in
-	   document order can be the hidden, empty one, so container lookups must
-	   pick the copy that is visible and actually has content.
-
-	Anything the current variant does not ship raises NoSuchElementException so
-	the caller can skip that task instead of aborting the whole run.
-	"""
+	"""Resilient semantic and multi-attribute selectors for the Microsoft Rewards & Bing UI."""
 
 	def __init__(self, driver: webdriver.Edge):
 		self.driver = driver
 
 	# ------------------------------------------------------------------
-	# helpers
+	# Helpers & Matchers
 	# ------------------------------------------------------------------
 
-	def resolve(self, xpath: str):
+	def resolve(self, xpath: str) -> WebElement:
 		return self.driver.find_element(By.XPATH, xpath)
 
-	def _container_by_id(self, element_id: str) -> WebElement:
-		"""Return the usable copy of an id that may be present more than once.
+	def _matches_any(self, text: str, needles: Union[str, Sequence[str]]) -> bool:
+		"""Case-insensitive check if any needle is contained in text."""
+		if not text:
+			return False
+		text_lower = text.lower()
+		if isinstance(needles, str):
+			return needles.lower() in text_lower
+		return any(n.lower() in text_lower for n in needles)
 
-		Only a copy that is both visible and has content is usable. A hidden copy
-		still exposes its links to find_elements, but they cannot be clicked and
-		their `.text` is empty, so returning one produces silent no-ops further
-		up. Raising instead lets the caller's WebDriverWait retry while the page
-		finishes hydrating.
-		"""
+	def _container_by_id(self, element_id: str) -> WebElement:
+		"""Return the usable copy of an ID that may be present more than once in responsive layout."""
 		matches = self.driver.find_elements(By.ID, element_id)
 
 		if not matches:
-			raise NoSuchElementException(f"no element with id {element_id!r}")
+			# Fallback: search by data-bi-name or class
+			matches = self.driver.find_elements(By.CSS_SELECTOR, f"[data-bi-name*='{element_id}'], [class*='{element_id}']")
+			if not matches:
+				raise NoSuchElementException(f"no element with id {element_id!r}")
 
 		for match in matches:
 			try:
@@ -80,200 +252,404 @@ class ElementSelectionUtils:
 				continue
 
 		raise NoSuchElementException(
-			f"{element_id!r} is present but no visible copy has content yet"
+			f"{element_id!r} is present but no visible copy has clickable content yet"
 		)
 
-	def _button_containing(self, needle: str, root: WebElement = None) -> WebElement:
-		"""First button whose visible text contains `needle` (case-insensitive)."""
+	def _button_containing(self, needles: Union[str, Sequence[str]], root: Optional[WebElement] = None) -> WebElement:
+		"""First button whose text or aria-label matches any of the target needles."""
 		scope = self.driver if root is None else root
-		needle = needle.lower()
 
 		for button in scope.find_elements(By.TAG_NAME, "button"):
 			try:
-				if needle in (button.text or "").lower():
+				if not button.is_displayed():
+					continue
+				text = button.text or ""
+				aria = button.get_attribute("aria-label") or ""
+				title = button.get_attribute("title") or ""
+				if self._matches_any(text, needles) or self._matches_any(aria, needles) or self._matches_any(title, needles):
 					return button
 			except StaleElementReferenceException:
 				continue
 
-		raise NoSuchElementException(f"no button containing {needle!r}")
+		needle_repr = needles if isinstance(needles, str) else list(needles)
+		raise NoSuchElementException(f"no button containing any of {needle_repr!r}")
 
-	def _link_containing(self, needle: str, root: WebElement = None) -> WebElement:
+	def _link_containing(self, needles: Union[str, Sequence[str]], root: Optional[WebElement] = None) -> WebElement:
+		"""First link whose text or aria-label matches any of the target needles."""
 		scope = self.driver if root is None else root
-		needle = needle.lower()
 
 		for link in scope.find_elements(By.TAG_NAME, "a"):
 			try:
-				if needle in (link.text or "").lower():
+				if not link.is_displayed():
+					continue
+				text = link.text or ""
+				aria = link.get_attribute("aria-label") or ""
+				if self._matches_any(text, needles) or self._matches_any(aria, needles):
 					return link
 			except StaleElementReferenceException:
 				continue
 
-		raise NoSuchElementException(f"no link containing {needle!r}")
+		needle_repr = needles if isinstance(needles, str) else list(needles)
+		raise NoSuchElementException(f"no link containing any of {needle_repr!r}")
 
 	# ------------------------------------------------------------------
-	# navigation
+	# Navigation Tabs & Points Balance
 	# ------------------------------------------------------------------
 
-	def get_earn_tab(self):
-		# The react-aria prefix is generated per build, so match on the suffix.
-		return self.driver.find_element(By.CSS_SELECTOR, '[id$="-tab-/earn"]')
+	def get_total_points_balance(self) -> Optional[int]:
+		"""Extract current total available rewards points balance from header or page state."""
+		# 1. Comprehensive JS inspection of header/nav elements and raw numbers (e.g. '6,302')
+		js_extractor = r"""
+		// Strategy A: Check top navigation / header bar for raw formatted balance (e.g. '6,302')
+		const headerContainers = [
+			document.querySelector('header'),
+			document.querySelector('nav'),
+			document.querySelector('[role="banner"]'),
+			document.querySelector('#header'),
+			document.querySelector('div[class*="header" i]'),
+			document.querySelector('div[class*="nav" i]'),
+			document.body
+		];
 
-	def get_dashboard_tab(self):
-		return self.driver.find_element(By.CSS_SELECTOR, '[id$="-tab-/dashboard"]')
+		for (const container of headerContainers) {
+			if (!container) continue;
+			// Check leaf text nodes inside header
+			const elements = container.querySelectorAll('span, div, p, a, button, b, strong');
+			for (const el of elements) {
+				if (el.children.length === 0) {
+					const text = (el.innerText || el.textContent || '').trim();
+					// Match comma-separated numbers like "6,302" or "15,400"
+					if (/^[0-9]{1,3}(,[0-9]{3})+$/.test(text)) {
+						return parseInt(text.replace(/,/g, ''), 10);
+					}
+				}
+			}
+		}
 
-	def get_sidebar_section(self):
+		// Strategy B: Check elements with ID or class containing point/balance
+		const pointSelectors = [
+			'#userPoints',
+			'[id*="userPoint" i]',
+			'[id*="balance" i]',
+			'[class*="user-points" i]',
+			'[class*="pointsValue" i]',
+			'[class*="points-balance" i]',
+			'[data-bi-name*="points" i]',
+			'header [aria-label*="point" i]',
+			'header [aria-label*="poäng" i]',
+		];
+		for (const sel of pointSelectors) {
+			const matches = document.querySelectorAll(sel);
+			for (const el of matches) {
+				const text = (el.innerText || el.getAttribute('aria-label') || '').trim();
+				const m = text.match(/([0-9,]+)/);
+				if (m) {
+					const val = parseInt(m[1].replace(/,/g, ''), 10);
+					if (val > 0) return val;
+				}
+			}
+		}
+
+		// Strategy C: Check React / global window preloaded state
+		if (window.__INITIAL_STATE__ && window.__INITIAL_STATE__.dashboard) {
+			const p = window.__INITIAL_STATE__.dashboard.userStatus?.availablePoints;
+			if (p && p > 0) return p;
+		}
+		if (window.rewardsUser && window.rewardsUser.availablePoints) {
+			return window.rewardsUser.availablePoints;
+		}
+
+		return null;
+		"""
+		try:
+			js_result = self.driver.execute_script(js_extractor)
+			if js_result is not None and int(js_result) > 0:
+				return int(js_result)
+		except Exception:
+			pass
+
+		# 2. Python Selenium fallback
+		selectors = [
+			"#userPoints",
+			"[class*='user-points']",
+			"[class*='pointsValue']",
+			"[class*='points-balance']",
+			"[data-bi-name*='points']",
+			"header [aria-label*='points' i]",
+			"header [aria-label*='poäng' i]",
+			"a[href*='rewards.bing.com'] [class*='point']",
+		]
+		for selector in selectors:
+			for elem in self.driver.find_elements(By.CSS_SELECTOR, selector):
+				try:
+					if elem.is_displayed():
+						text = elem.text or elem.get_attribute("aria-label") or ""
+						match = re.search(r"([\d,]+)", text)
+						if match:
+							val = int(match.group(1).replace(",", ""))
+							if val > 0:
+								return val
+				except StaleElementReferenceException:
+					continue
+
+		return None
+
+	def get_today_points(self) -> Optional[int]:
+		"""Extract today's points earned from the 'Today's points' card on the page."""
+		js_today_extractor = r"""
+		const allDivs = document.querySelectorAll('div, section, a');
+		for (const card of allDivs) {
+			const text = (card.innerText || card.textContent || '').trim();
+			if (/(?:today'?s\s+points|dagens\s+poäng|heutige\s+punkte|puntos\s+de\s+hoy|points\s+du\s+jour)/i.test(text)) {
+				const lines = text.split('\n');
+				for (const line of lines) {
+					const clean = line.trim();
+					if (/^[0-9]+$/.test(clean)) {
+						return parseInt(clean, 10);
+					}
+					const m = clean.match(/(?:today'?s\s+points|dagens\s+poäng|heutige\s+punkte)\D*?([0-9]+)/i);
+					if (m) {
+						return parseInt(m[1], 10);
+					}
+				}
+			}
+		}
+		return null;
+		"""
+		try:
+			res = self.driver.execute_script(js_today_extractor)
+			if res is not None:
+				return int(res)
+		except Exception:
+			pass
+		return None
+
+	def get_earn_tab(self) -> WebElement:
+		"""Earn page tab with multi-attribute fallbacks."""
+		selectors = [
+			(By.CSS_SELECTOR, '[id$="-tab-/earn"]'),
+			(By.CSS_SELECTOR, 'a[href*="/earn"]'),
+			(By.XPATH, "//a[contains(@href, '/earn') or contains(translate(text(), 'EARN', 'earn'), 'earn')]"),
+			(By.XPATH, "//a[contains(translate(text(), 'TJÄNA', 'tjäna'), 'tjäna')]"),
+			(By.CSS_SELECTOR, '[data-bi-name*="earn"]')
+		]
+		for by, selector in selectors:
+			try:
+				elem = self.driver.find_element(by, selector)
+				if elem.is_displayed():
+					return elem
+			except NoSuchElementException:
+				continue
+		raise NoSuchElementException("Earn tab not found")
+
+	def get_dashboard_tab(self) -> WebElement:
+		"""Dashboard page tab with multi-attribute fallbacks."""
+		selectors = [
+			(By.CSS_SELECTOR, '[id$="-tab-/dashboard"]'),
+			(By.CSS_SELECTOR, 'a[href*="/dashboard"]'),
+			(By.XPATH, "//a[contains(@href, '/dashboard') or contains(translate(text(), 'DASHBOARD', 'dashboard'), 'dashboard')]"),
+			(By.XPATH, "//a[contains(translate(text(), 'ÖVERSIKT', 'översikt'), 'översikt')]"),
+			(By.CSS_SELECTOR, '[data-bi-name*="dashboard"]')
+		]
+		for by, selector in selectors:
+			try:
+				elem = self.driver.find_element(by, selector)
+				if elem.is_displayed():
+					return elem
+			except NoSuchElementException:
+				continue
+		raise NoSuchElementException("Dashboard tab not found")
+
+	def get_sidebar_section(self) -> WebElement:
+		"""Locate active sliding sidebar section."""
 		for section in self.driver.find_elements(By.TAG_NAME, "section"):
 			try:
-				# get_dom_attribute returns None for sections without an id,
-				# so normalise before comparing.
-				if (section.get_dom_attribute("id") or "").startswith("react-aria"):
-					return section
+				sid = section.get_dom_attribute("id") or ""
+				aria_role = section.get_dom_attribute("role") or ""
+				if sid.startswith("react-aria") or aria_role == "dialog" or "sidebar" in sid.lower():
+					if section.is_displayed():
+						return section
 			except StaleElementReferenceException:
 				continue
 
 		raise NoSuchElementException("sidebar section not found")
 
 	# ------------------------------------------------------------------
-	# daily set
+	# Daily Set
 	# ------------------------------------------------------------------
 
 	def _streaks_button(self, index: int) -> WebElement:
-		"""Positional fallback inside the streaks section.
-
-		Same node the original absolute XPath pointed at, but anchored on the
-		section id so an extra section earlier in the page cannot shift it.
-		"""
+		"""Positional fallback inside the streaks section."""
 		streaks = self.driver.find_element(By.ID, "streaks")
+		return streaks.find_element(By.XPATH, f".//button[{index}]")
 
-		return streaks.find_element(By.XPATH, f"./div/div[2]/div/div/button[{index}]")
-
-	def get_open_daily_set_button(self):
-		# Lives in the streaks section, not in a section of its own. Match on
-		# "daily set streak" rather than "daily set", because the level up
-		# section also has "Complete the Daily Set for 7 days in a row".
+	def get_open_daily_set_button(self) -> WebElement:
 		try:
 			return self._button_containing(Labels.DAILY_SET_STREAK)
 		except NoSuchElementException:
-			return self._streaks_button(3)
+			try:
+				return self._streaks_button(3)
+			except NoSuchElementException:
+				# General fallback in streaks
+				streaks = self.driver.find_element(By.ID, "streaks")
+				buttons = [b for b in streaks.find_elements(By.TAG_NAME, "button") if b.is_displayed()]
+				if buttons:
+					return buttons[0]
+				raise NoSuchElementException("Open daily set button not found")
 
-	def get_daily_set_elements(self):
-		# The first link in the opened panel is the progress row, not an activity.
-		return self.get_sidebar_section().find_elements(By.TAG_NAME, "a")[1:]
+	def get_daily_set_elements(self) -> List[WebElement]:
+		sidebar = self.get_sidebar_section()
+		links = sidebar.find_elements(By.TAG_NAME, "a")
+		# The first link is typically the progress/streak header row
+		return links[1:] if len(links) > 1 else links
 
 	# ------------------------------------------------------------------
-	# explore on bing (absent in en-US, present in some other markets)
+	# Explore on Bing
 	# ------------------------------------------------------------------
 
-	def get_explore_on_bing_elements(self):
+	def get_explore_on_bing_elements(self) -> List[WebElement]:
 		try:
 			container = self._container_by_id("exploreonbing")
 		except NoSuchElementException:
 			return []
 
-		return container.find_elements(By.TAG_NAME, "a")
+		return [a for a in container.find_elements(By.TAG_NAME, "a") if a.is_displayed()]
 
 	# ------------------------------------------------------------------
-	# visual search
+	# Visual Search
 	# ------------------------------------------------------------------
 
-	def get_open_visual_search_sidebar(self):
-		try:
-			return self._button_containing(Labels.VISUAL_SEARCH_STREAK)
-		except NoSuchElementException:
-			# Not every layout ships this entry point. Where it does but the
-			# label differs, fall back to the original position in streaks.
-			return self._streaks_button(5)
+	def get_open_visual_search_sidebar(self) -> WebElement:
+		"""Locate visual search entry button if present in active streaks."""
+		return self._button_containing(Labels.VISUAL_SEARCH_STREAK)
 
-	def get_search_now_link_from_visual_search_sidebar(self):
+	def get_search_now_link_from_visual_search_sidebar(self) -> WebElement:
 		sidebar = self.get_sidebar_section()
-
 		try:
-			return self._link_containing("search now", sidebar)
+			return self._link_containing(Labels.SEARCH_NOW, sidebar)
 		except NoSuchElementException:
-			# Fall back to the original positional behaviour.
-			links = sidebar.find_elements(By.TAG_NAME, "a")
-
+			links = [a for a in sidebar.find_elements(By.TAG_NAME, "a") if a.is_displayed()]
 			if len(links) < 2:
 				raise NoSuchElementException("visual search sidebar has no usable link")
-
 			return links[1]
 
-	def get_visual_search_button(self):
-		return self.driver.find_element(By.CSS_SELECTOR, "#sb_form > div.camera.icon")
+	def get_visual_search_button(self) -> WebElement:
+		selectors = [
+			(By.CSS_SELECTOR, "#sb_form > div.camera.icon"),
+			(By.CSS_SELECTOR, "#sb_form .camera"),
+			(By.CSS_SELECTOR, "[aria-label*='Visual' i]"),
+			(By.CSS_SELECTOR, "[aria-label*='Visuell' i]"),
+			(By.CSS_SELECTOR, ".camera.icon"),
+		]
+		for by, selector in selectors:
+			try:
+				elem = self.driver.find_element(by, selector)
+				if elem.is_displayed():
+					return elem
+			except NoSuchElementException:
+				continue
+		raise NoSuchElementException("Visual search camera button not found")
 
-	def get_visual_search_file_input(self):
-		return self.driver.find_element(By.CSS_SELECTOR, "#sb_fileinput")
+	def get_visual_search_file_input(self) -> WebElement:
+		selectors = [
+			(By.CSS_SELECTOR, "#sb_fileinput"),
+			(By.CSS_SELECTOR, "input[type='file'][name*='image']"),
+			(By.CSS_SELECTOR, "input[type='file']"),
+		]
+		for by, selector in selectors:
+			try:
+				return self.driver.find_element(by, selector)
+			except NoSuchElementException:
+				continue
+		raise NoSuchElementException("Visual search file input not found")
 
 	# ------------------------------------------------------------------
-	# cards
+	# Cards & Activities
 	# ------------------------------------------------------------------
 
-	def get_all_misc_cards(self):
-		return self._container_by_id("moreactivities").find_elements(By.TAG_NAME, "a")
+	def get_all_misc_cards(self) -> List[WebElement]:
+		try:
+			container = self._container_by_id("moreactivities")
+			return container.find_elements(By.TAG_NAME, "a")
+		except NoSuchElementException:
+			candidates = self.driver.find_elements(By.CSS_SELECTOR, "section[id*='activity' i] a, section[id*='more' i] a")
+			return [c for c in candidates if c.is_displayed()]
 
-	def extract_card_descriptions(self, card: WebElement):
+	def extract_card_descriptions(self, card: WebElement) -> str:
 		try:
 			return card.find_element(By.CSS_SELECTOR, "p:nth-child(2)").text
 		except NoSuchElementException:
 			paragraphs = card.find_elements(By.TAG_NAME, "p")
-
 			return paragraphs[1].text if len(paragraphs) > 1 else (card.text or "")
 
-	def _card_status_element(self, card: WebElement):
-		return card.find_element(By.CSS_SELECTOR, "div.flex.w-full.items-center.gap-2")
+	def _card_status_element(self, card: WebElement) -> WebElement:
+		selectors = [
+			(By.CSS_SELECTOR, "div.flex.w-full.items-center.gap-2"),
+			(By.CSS_SELECTOR, "[class*='items-center'][class*='gap-']"),
+			(By.XPATH, ".//div[contains(@class, 'items-center')]")
+		]
+		for by, selector in selectors:
+			try:
+				return card.find_element(by, selector)
+			except NoSuchElementException:
+				continue
+		return card
 
-	def card_is_complete(self, card: WebElement):
+	def card_is_complete(self, card: WebElement) -> bool:
 		try:
-			status = self._card_status_element(card).text
+			status = self._card_status_element(card).text or card.text or ""
 		except NoSuchElementException:
 			return False
+		return self._matches_any(status, Labels.CARD_COMPLETED)
 
-		return Labels.CARD_COMPLETED in (status or "").lower()
-
-	def get_card_point_value(self, card: WebElement):
+	def get_card_point_value(self, card: WebElement) -> int:
 		try:
 			elem = self._card_status_element(card).find_element(By.TAG_NAME, "p")
+			text = elem.text or ""
 		except NoSuchElementException:
-			return 0
+			text = card.text or ""
 
-		# Rendered as "+10", and other variants add a unit, so pull the digits out
-		# rather than relying on int() accepting the exact string.
-		digits = re.search(r"\d+", elem.text or "")
-
+		digits = re.search(r"\d+", text)
 		return int(digits.group()) if digits else 0
 
 	def element_is_fully_in_viewport(self, elem: WebElement) -> bool:
 		js_viewport_check = """
-var elem = arguments[0];
-var box = elem.getBoundingClientRect();
-
-return (
-	box.top >= 0 &&
-	box.left >= 0 &&
-	box.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-	box.right <= (window.innerWidth || document.documentElement.clientWidth)
-);
-"""
-
-		return self.driver.execute_script(js_viewport_check, elem)
+		var elem = arguments[0];
+		var box = elem.getBoundingClientRect();
+		return (
+			box.top >= 0 &&
+			box.left >= 0 &&
+			box.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+			box.right <= (window.innerWidth || document.documentElement.clientWidth)
+		);
+		"""
+		try:
+			return self.driver.execute_script(js_viewport_check, elem)
+		except Exception:
+			return False
 
 	# ------------------------------------------------------------------
-	# points breakdown
+	# Points Breakdown
 	# ------------------------------------------------------------------
 
-	def get_points_breakdown_button(self):
-		return self._button_containing(Labels.POINTS_BREAKDOWN)
+	def get_points_breakdown_button(self) -> WebElement:
+		try:
+			return self._button_containing(Labels.POINTS_BREAKDOWN)
+		except NoSuchElementException:
+			# Fallback: look for button with points icon or data attribute
+			buttons = self.driver.find_elements(By.CSS_SELECTOR, "[data-bi-name*='breakdown'], button[id*='breakdown']")
+			for b in buttons:
+				if b.is_displayed():
+					return b
+			raise NoSuchElementException("Points breakdown button not found")
 
-	def get_close_button_on_points_breakdown(self):
+	def get_close_button_on_points_breakdown(self) -> WebElement:
 		return self.get_generic_sidebar_close_button()
 
-	def get_points_earned_from_searches_on_points_breakdown(self):
-		"""Return (earned, max) for the Bing search row of the breakdown panel.
-
-		The value renders as two spans, "3" and "/15", so an XPath on text()
-		matches only the second half. Read the panel's rendered text instead and
-		anchor on the row label, because several rows share the same value class
-		and a reordering would otherwise silently return the wrong number.
+	def get_points_earned_from_searches_on_points_breakdown(self, search_type: str = "pc") -> Tuple[int, int]:
+		"""Parse (earned, max) for Bing search row in breakdown panel.
+		
+		search_type: 'pc' (Desktop searches) or 'mobile' (Mobile searches).
 		"""
 		sidebar = self.get_sidebar_section()
 		text = sidebar.text or ""
@@ -281,79 +657,144 @@ return (
 
 		def parse(candidate: str):
 			match = re.fullmatch(r"([\d,]+)\s*/\s*([\d,]+)", candidate)
-
 			if not match:
 				return None
-
 			return int(match.group(1).replace(",", "")), int(match.group(2).replace(",", ""))
 
-		for index, line in enumerate(lines):
-			if "bing search" in line.lower():
-				for candidate in lines[index + 1:index + 3]:
-					parsed = parse(candidate)
+		if search_type.lower() == "mobile":
+			mobile_keywords = (
+				"mobile search", "mobilsökning", "mobila sökningar", "mobil sökning",
+				"suche auf mobilen geräten", "búsqueda en el móvil", "recherche sur mobile",
+				"ricerca su cellulare"
+			)
+			for index, line in enumerate(lines):
+				if any(k in line.lower() for k in mobile_keywords):
+					for candidate in lines[index + 1:index + 4]:
+						parsed = parse(candidate)
+						if parsed:
+							return parsed
+			# If mobile search is not in breakdown sidebar (e.g. Level 1 accounts where mobile is locked)
+			raise NoSuchElementException("Mobile search quota row not found in breakdown sidebar")
 
+		# Default: PC / standard search
+		pc_keywords = (
+			"pc search", "datorsökning", "pc-suche", "búsqueda en pc",
+			"recherche sur pc", "bing search", "bingsökning", "search", "sökning"
+		)
+		for index, line in enumerate(lines):
+			line_lower = line.lower()
+			if any(k in line_lower for k in pc_keywords):
+				# Exclude lines that explicitly mention mobile
+				if any(m in line_lower for m in ("mobile", "mobil", "móvil")):
+					continue
+				for candidate in lines[index + 1:index + 4]:
+					parsed = parse(candidate)
 					if parsed:
 						return parsed
 
-		# Fall back to the first fraction anywhere in the panel.
+		# Fallback: find any fraction anywhere in panel
 		match = re.search(r"([\d,]+)\s*/\s*([\d,]+)", text)
-
 		if match:
 			return int(match.group(1).replace(",", "")), int(match.group(2).replace(",", ""))
 
 		raise NoSuchElementException("no points fraction found in the breakdown sidebar")
 
 	# ------------------------------------------------------------------
-	# bonus
+	# Bonus Points
 	# ------------------------------------------------------------------
 
-	def get_bonus_button_on_dashboard(self):
+	def get_bonus_button_on_dashboard(self) -> WebElement:
 		return self._button_containing(Labels.READY_TO_CLAIM)
 
-	def get_claim_bonus_points_button(self):
+	def get_claim_bonus_points_button(self) -> WebElement:
 		sidebar = self.get_sidebar_section()
 		buttons = sidebar.find_elements(By.TAG_NAME, "button")
 
-		# Prefer the button whose whole label is the action. A substring match
-		# would hit the "Ready to claim" heading before the actual Claim button.
+		# Exact match preferred
 		for button in buttons:
 			try:
-				if (button.text or "").strip().lower() == Labels.CLAIM:
+				if not button.is_displayed():
+					continue
+				text = (button.text or "").strip().lower()
+				if any(text == c.lower() for c in Labels.CLAIM):
 					return button
 			except StaleElementReferenceException:
 				continue
 
+		# Substring match
 		for button in buttons:
 			try:
-				if Labels.CLAIM in (button.text or "").lower():
+				if not button.is_displayed():
+					continue
+				if self._matches_any(button.text or "", Labels.CLAIM):
 					return button
 			except StaleElementReferenceException:
 				continue
 
-		if len(buttons) < 3:
-			raise NoSuchElementException("bonus sidebar has no claim button")
+		if len(buttons) >= 3:
+			return buttons[2]
 
-		return buttons[2]
+		raise NoSuchElementException("bonus sidebar has no claim button")
 
-	def get_generic_sidebar_close_button(self):
+	def get_generic_sidebar_close_button(self) -> WebElement:
 		sidebar = self.get_sidebar_section()
+		close_selectors = [
+			"button[aria-label*='lose' i]",
+			"button[aria-label*='täng' i]",
+			"button[aria-label*='chließen' i]",
+			"button[aria-label*='errar' i]",
+			"button[aria-label*='ermer' i]",
+			"button[data-bi-name*='close' i]"
+		]
+		for selector in close_selectors:
+			try:
+				btn = sidebar.find_element(By.CSS_SELECTOR, selector)
+				if btn.is_displayed():
+					return btn
+			except NoSuchElementException:
+				continue
 
-		try:
-			return sidebar.find_element(By.CSS_SELECTOR, "button[aria-label*='lose']")
-		except NoSuchElementException:
-			buttons = sidebar.find_elements(By.TAG_NAME, "button")
-
-			if not buttons:
-				raise NoSuchElementException("sidebar has no buttons")
-
+		buttons = [b for b in sidebar.find_elements(By.TAG_NAME, "button") if b.is_displayed()]
+		if buttons:
 			return buttons[0]
 
+		raise NoSuchElementException("sidebar has no buttons")
+
 	# ------------------------------------------------------------------
-	# bing search page
+	# Bing Search Page
 	# ------------------------------------------------------------------
 
-	def get_bing_search_bar(self):
-		return self.driver.find_element(By.TAG_NAME, "textarea")
+	def get_bing_search_bar(self) -> WebElement:
+		selectors = [
+			(By.CSS_SELECTOR, "textarea#sb_form_q"),
+			(By.CSS_SELECTOR, "textarea[name='q']"),
+			(By.CSS_SELECTOR, "input#sb_form_q"),
+			(By.CSS_SELECTOR, "input[name='q']"),
+			(By.TAG_NAME, "textarea"),
+		]
+		for by, selector in selectors:
+			try:
+				elem = self.driver.find_element(by, selector)
+				if elem.is_displayed():
+					return elem
+			except NoSuchElementException:
+				continue
+		raise NoSuchElementException("Bing search bar not found")
 
-	def get_clear_bing_search_query_button(self):
-		return self.driver.find_element(By.ID, "sw_clx")
+	def get_clear_bing_search_query_button(self) -> WebElement:
+		selectors = [
+			(By.ID, "sw_clx"),
+			(By.CSS_SELECTOR, ".b_searchboxForm .b_clx"),
+			(By.CSS_SELECTOR, "[aria-label*='Clear' i]"),
+			(By.CSS_SELECTOR, "[aria-label*='Rensa' i]"),
+			(By.CSS_SELECTOR, "[title*='Clear' i]"),
+			(By.CSS_SELECTOR, "#sb_form .b_clx"),
+		]
+		for by, selector in selectors:
+			try:
+				elem = self.driver.find_element(by, selector)
+				if elem.is_displayed():
+					return elem
+			except NoSuchElementException:
+				continue
+		raise NoSuchElementException("Bing clear query button not found")

--- a/src/fitts_law.py
+++ b/src/fitts_law.py
@@ -35,15 +35,22 @@ class Trial:
 
 
 def get_screen_size() -> Tuple[int, int]:
-	user32 = ctypes.windll.user32
-	width = user32.GetSystemMetrics(0)
-	height = user32.GetSystemMetrics(1)
-	return width, height
+	if hasattr(ctypes, "windll"):
+		user32 = ctypes.windll.user32
+		return user32.GetSystemMetrics(0), user32.GetSystemMetrics(1)
+	try:
+		root = tk.Tk()
+		root.withdraw()
+		w, h = root.winfo_screenwidth(), root.winfo_screenheight()
+		root.destroy()
+		return w, h
+	except Exception:
+		return 1920, 1080
 
 
 def set_cursor_position(x: int, y: int) -> None:
-	user32 = ctypes.windll.user32
-	user32.SetCursorPos(int(x), int(y))
+	if hasattr(ctypes, "windll"):
+		ctypes.windll.user32.SetCursorPos(int(x), int(y))
 
 
 def point_in_rectangle(px: float, py: float, x: float, y: float, w: float, h: float) -> bool:

--- a/src/llm_utils.py
+++ b/src/llm_utils.py
@@ -1,6 +1,18 @@
-from typing import Generator
+import os
+import re
 import random
+import time
+from pathlib import Path
+from typing import Generator, Optional, List, Tuple
+import urllib.request
+import json
 import ollama
+
+from constants import (
+	OLLAMA_HOST,
+	DEFAULT_MODEL,
+	MODEL_FALLBACK_PREFERENCES,
+)
 
 DEFAULT_SYSTEM_PROMPT_FOR_SEARCH_QUEST = (
 	"You are a helpful assistant tasked with creating a search query based on a directive. "
@@ -13,10 +25,10 @@ DEFAULT_SYSTEM_PROMPT_FOR_SEARCH_QUEST = (
 	"as those answers include instructions to perform a search rather than just the search query itself. "
 	"Additionally, be specific, e.g. if a prompt asks you to search for vacation flights, include "
 	"a specific destination rather than just searching 'vacation flights'. The current year is 2026. "
-	"Make your query concise, ideally 6 words or less, and do not include any punctuation. "
+	"Make your query concise, ideally 6 words or less, and do not include any punctuation."
 )
 
-DEFAULT_USER_PROMPT_FOR_SEARCH_QUEST_WITHOUT_DESC = """Base your search query on the following task description: """
+DEFAULT_USER_PROMPT_FOR_SEARCH_QUEST_WITHOUT_DESC = "Base your search query on the following task description: "
 
 DEFAULT_SYSTEM_PROMPT_FOR_SEARCH_POINTS = (
 	"The user is interested in learning more about topics related to a word that will be given to you. "
@@ -27,88 +39,261 @@ DEFAULT_SYSTEM_PROMPT_FOR_SEARCH_POINTS = (
 	"The search queries should ideally be short (6 words max) and do not need to be fully fledged questions, but they should be unique. The current year is 2026."
 )
 
-DEFAULT_USER_PROMPT_FOR_SEARCH_POINTS_WITHOUT_DESC = """Generate the first search query based on the following word: """
+DEFAULT_USER_PROMPT_FOR_SEARCH_POINTS_WITHOUT_DESC = "Generate the first search query based on the following word: "
+USER_PROMPT_FOR_SEARCH_QUERY_CONTINUATION = "Generate the next search query."
 
-USER_PROMPT_FOR_SEARCH_QUERY_CONTINUATION = """Generate the next search query."""
+# Load nouns safely relative to this file or project root
+_NOUNS_FILE = Path(__file__).parent.parent / "nouns.txt"
+if not _NOUNS_FILE.exists():
+	_NOUNS_FILE = Path("nouns.txt")
 
-# Without an explicit timeout a stalled or cold ollama backend blocks the whole
-# run forever, which is fatal for an unattended scheduled run.
-_CLIENT = ollama.Client(timeout=180)
-
-MAX_EMPTY_RETRIES = 5
-
-
-def get_ollama_response(messages: list[dict[str, str]], model: str="gemma4:cloud") -> str:
-	response = _CLIENT.chat(
-		model=model,
-		messages=messages
-	)
-
-	return response.message.content
-
-
-def get_nonempty_ollama_response(messages: list[dict[str, str]]) -> str:
-	"""Retry a bounded number of times instead of spinning forever on empties."""
-	for attempt in range(MAX_EMPTY_RETRIES):
-		response = get_ollama_response(messages)
-
-		if response and response.strip():
-			return response
-
-		print(f"[WARNING] Empty LLM response, retry {attempt + 1}/{MAX_EMPTY_RETRIES}")
-
-	raise RuntimeError(f"LLM returned nothing usable after {MAX_EMPTY_RETRIES} attempts")
-
-def get_search_query_from_task_description(task_description: str) -> str:
-	# compat
-	if "lyrics of your favorite song" in task_description.lower(): return "sweet caroline lyrics"
-
-	messages = [
-		{
-			"role": "system",
-			"content": DEFAULT_SYSTEM_PROMPT_FOR_SEARCH_QUEST
-		},
-		{
-			"role": "user",
-			"content": DEFAULT_USER_PROMPT_FOR_SEARCH_QUEST_WITHOUT_DESC + task_description
-		}
+if _NOUNS_FILE.exists():
+	NOUNS = [
+		noun.strip().lower() for noun in _NOUNS_FILE.read_text(encoding="utf-8").splitlines()
+		if len(noun.strip()) >= 3
 	]
-
-	response = get_nonempty_ollama_response(messages)
-
-	return response.lower()
-
-def get_related_search_queries(seed_word: str, num_queries: int=20) -> Generator[str, None, None]:
-	messages = [
-		{
-			"role": "system",
-			"content": DEFAULT_SYSTEM_PROMPT_FOR_SEARCH_POINTS
-		},
-		{
-			"role": "user",
-			"content": DEFAULT_USER_PROMPT_FOR_SEARCH_POINTS_WITHOUT_DESC + seed_word
-		}
-	]
-
-	for _ in range(num_queries):
-		response = get_nonempty_ollama_response(messages)
-
-		yield response.lower()
-
-		messages.append({
-			"role": "assistant",
-			"content": response
-		})
-
-		messages.append({
-			"role": "user",
-			"content": USER_PROMPT_FOR_SEARCH_QUERY_CONTINUATION
-		})
-
-NOUNS = [
-	noun.strip().lower() for noun in open("nouns.txt", "r").read().splitlines()
-	if len(noun.strip()) >= 3
-]
+else:
+	NOUNS = ["technology", "astronomy", "geography", "history", "biology", "space", "weather", "music", "art"]
 
 def get_random_noun() -> str:
 	return random.choice(NOUNS)
+
+
+# Client instance
+_CLIENT = ollama.Client(host=OLLAMA_HOST, timeout=30)
+_RESOLVED_MODEL: Optional[str] = None
+_OLLAMA_AVAILABLE: Optional[bool] = None
+
+
+def check_ollama_health(host: str = OLLAMA_HOST, timeout: float = 3.0) -> Tuple[bool, List[str], str]:
+	"""Check connection to Ollama daemon and list locally installed models.
+	
+	Returns: (is_healthy, list_of_model_names, message)
+	"""
+	# Direct HTTP check first for fast timeout handling
+	tags_url = f"{host.rstrip('/')}/api/tags"
+	try:
+		req = urllib.request.Request(tags_url, headers={"User-Agent": "RewardsFarmer/1.0"})
+		with urllib.request.urlopen(req, timeout=timeout) as response:
+			if response.status == 200:
+				data = json.loads(response.read().decode("utf-8"))
+				models = [m.get("name", "") for m in data.get("models", [])]
+				return True, models, f"Connected to Ollama at {host} ({len(models)} models available)"
+			return False, [], f"Ollama returned HTTP status {response.status}"
+	except urllib.error.HTTPError as exc:
+		if exc.code == 401:
+			return False, [], f"Ollama authentication failed (HTTP 401 Unauthorized) at {host}"
+		return False, [], f"Ollama HTTP error {exc.code} at {host}"
+	except Exception as exc:
+		return False, [], f"Could not connect to Ollama daemon at {host}: {exc}"
+
+
+def resolve_available_model(requested_model: str = DEFAULT_MODEL) -> Tuple[str, bool]:
+	"""Resolve the best available local model, falling back through preferences or offline mode."""
+	global _RESOLVED_MODEL, _OLLAMA_AVAILABLE
+	
+	healthy, installed_models, msg = check_ollama_health()
+	_OLLAMA_AVAILABLE = healthy
+	
+	if not healthy:
+		print(f"[WARNING] {msg}. Falling back to offline query synthesizer.")
+		_RESOLVED_MODEL = "offline"
+		return "offline", False
+
+	# Normalize installed model names (strip :latest tag for loose matching)
+	installed_set = set(installed_models)
+	base_installed_map = {m.split(":")[0]: m for m in installed_models}
+
+	# 1. Exact match
+	if requested_model in installed_set:
+		_RESOLVED_MODEL = requested_model
+		print(f"[INFO] Using requested Ollama model: {requested_model}")
+		return requested_model, True
+
+	# 2. Match without tag (e.g. requested 'llama3.2', found 'llama3.2:latest')
+	req_base = requested_model.split(":")[0]
+	if req_base in base_installed_map:
+		matched = base_installed_map[req_base]
+		_RESOLVED_MODEL = matched
+		print(f"[INFO] Using matched Ollama model: {matched} (requested {requested_model})")
+		return matched, True
+
+	# 3. Fallback preference list
+	for pref in MODEL_FALLBACK_PREFERENCES:
+		pref_base = pref.split(":")[0]
+		if pref in installed_set:
+			_RESOLVED_MODEL = pref
+			print(f"[INFO] Model '{requested_model}' not found. Falling back to preference: {pref}")
+			return pref, True
+		if pref_base in base_installed_map:
+			matched = base_installed_map[pref_base]
+			_RESOLVED_MODEL = matched
+			print(f"[INFO] Model '{requested_model}' not found. Falling back to matched preference: {matched}")
+			return matched, True
+
+	# 4. Any installed model if list is non-empty
+	if installed_models:
+		fallback = installed_models[0]
+		_RESOLVED_MODEL = fallback
+		print(f"[INFO] Preferred models not found. Using installed model: {fallback}")
+		return fallback, True
+
+	print("[WARNING] Ollama is running but has no models installed. Falling back to offline query generator.")
+	_RESOLVED_MODEL = "offline"
+	return "offline", False
+
+
+def get_active_model() -> str:
+	global _RESOLVED_MODEL
+	if _RESOLVED_MODEL is None:
+		model, _ = resolve_available_model()
+		_RESOLVED_MODEL = model
+	return _RESOLVED_MODEL
+
+
+# ======================================================================
+# Offline Query Synthesizer (Fallback when Ollama is unavailable)
+# ======================================================================
+
+SEARCH_TEMPLATES = (
+	"{noun} facts and history",
+	"latest developments in {noun}",
+	"best {noun} tips 2026",
+	"how does {noun} work",
+	"{noun} vs {noun2} comparison",
+	"beginner guide to {noun}",
+	"why is {noun} important in 2026",
+	"interesting facts about {noun}",
+	"top {noun} examples",
+	"{noun} research and studies",
+	"understanding {noun} concepts",
+	"future of {noun} technology",
+)
+
+def get_fallback_search_query(seed_or_desc: str = "") -> str:
+	"""Generate a realistic, randomized search query offline without LLM."""
+	n1 = get_random_noun()
+	n2 = get_random_noun()
+	
+	if seed_or_desc:
+		cleaned = re.sub(r"(?i)\b(search\s+for|search\s+on\s+bing\s+for|find|explore|learn\s+about|look\s+up)\b", "", seed_or_desc)
+		cleaned = re.sub(r"[^\w\s]", " ", cleaned).strip()
+		words = [w for w in cleaned.split() if len(w) > 2]
+		if words:
+			extracted = " ".join(words[:4])
+			return f"{extracted} 2026".strip().lower()
+
+	template = random.choice(SEARCH_TEMPLATES)
+	return template.format(noun=n1, noun2=n2).lower()
+
+
+def get_fallback_related_queries(seed_word: str, num_queries: int = 20) -> Generator[str, None, None]:
+	"""Generate a chain of themed search queries offline."""
+	seed = seed_word.strip().lower()
+	subtopics = [
+		f"{seed} definition and overview",
+		f"{seed} history and origins",
+		f"types of {seed}",
+		f"{seed} applications and uses",
+		f"{seed} benefits and advantages",
+		f"future trends in {seed} 2026",
+		f"{seed} best practices",
+		f"{seed} tutorials and guide",
+		f"{seed} vs {get_random_noun()}",
+		f"innovations in {seed}",
+		f"{seed} real world examples",
+		f"{seed} statistics and facts",
+	]
+	
+	for i in range(num_queries):
+		if i < len(subtopics):
+			yield subtopics[i]
+		else:
+			n = get_random_noun()
+			yield f"{seed} {n} insights 2026"
+
+
+# ======================================================================
+# LLM Search Query Generation with Exponential Backoff
+# ======================================================================
+
+def get_ollama_response_with_retry(
+	messages: List[dict],
+	model: Optional[str] = None,
+	max_retries: int = 3,
+	base_delay: float = 1.0,
+) -> Optional[str]:
+	"""Execute Ollama chat with exponential backoff retries and jitter."""
+	active_model = model or get_active_model()
+	
+	if active_model == "offline":
+		return None
+
+	for attempt in range(1, max_retries + 1):
+		try:
+			response = _CLIENT.chat(
+				model=active_model,
+				messages=messages,
+				options={"temperature": 0.7, "top_p": 0.9}
+			)
+			content = response.message.content if hasattr(response, "message") else ""
+			if content and content.strip():
+				# Clean any markdown quotation marks or prefixes
+				clean = content.strip().strip('"\'`').replace("\n", " ").strip()
+				return clean
+			print(f"[WARNING] Empty response from Ollama (attempt {attempt}/{max_retries})")
+		except Exception as exc:
+			print(f"[WARNING] Ollama query failed (attempt {attempt}/{max_retries}): {exc}")
+
+		if attempt < max_retries:
+			backoff = base_delay * (2 ** (attempt - 1)) + random.uniform(0.2, 0.8)
+			time.sleep(backoff)
+
+	return None
+
+
+def get_search_query_from_task_description(task_description: str) -> str:
+	"""Extract search query from card task description using Ollama or offline fallback."""
+	# Compatibility check
+	if "lyrics of your favorite song" in task_description.lower():
+		return "sweet caroline lyrics"
+
+	messages = [
+		{"role": "system", "content": DEFAULT_SYSTEM_PROMPT_FOR_SEARCH_QUEST},
+		{"role": "user", "content": DEFAULT_USER_PROMPT_FOR_SEARCH_QUEST_WITHOUT_DESC + task_description}
+	]
+
+	response = get_ollama_response_with_retry(messages)
+	if response:
+		return response.lower()
+
+	# Fallback if Ollama unreachable
+	return get_fallback_search_query(task_description)
+
+
+def get_related_search_queries(seed_word: str, num_queries: int = 20) -> Generator[str, None, None]:
+	"""Generate chained, branching search queries for daily search quota."""
+	active_model = get_active_model()
+	
+	if active_model == "offline":
+		yield from get_fallback_related_queries(seed_word, num_queries)
+		return
+
+	messages = [
+		{"role": "system", "content": DEFAULT_SYSTEM_PROMPT_FOR_SEARCH_POINTS},
+		{"role": "user", "content": DEFAULT_USER_PROMPT_FOR_SEARCH_POINTS_WITHOUT_DESC + seed_word}
+	]
+
+	for _ in range(num_queries):
+		response = get_ollama_response_with_retry(messages, model=active_model)
+
+		if not response:
+			# If LLM failed during batch, yield offline fallback
+			yield get_fallback_search_query(seed_word)
+			continue
+
+		clean_query = response.lower()
+		yield clean_query
+
+		messages.append({"role": "assistant", "content": clean_query})
+		messages.append({"role": "user", "content": USER_PROMPT_FOR_SEARCH_QUERY_CONTINUATION})

--- a/src/main.py
+++ b/src/main.py
@@ -1,26 +1,83 @@
+import sys
+import time
+import argparse
+from typing import Dict
+from browser_lifecycle import BrowserManager
 import rewards_tasks
-import mouse_trajectory
-import mimic_typing
-from selenium import webdriver
-from constants import USER_DATA_DIR, PROFILE_NAME
+import llm_utils
+import points_tracker
+from constants import USER_DATA_DIR, PROFILE_NAME, DEFAULT_MODEL
 
-options = webdriver.EdgeOptions()
 
-options.add_experimental_option("excludeSwitches", ["enable-automation"])
-options.add_experimental_option('useAutomationExtension', False)
-options.add_argument("--disable-blink-features=AutomationControlled")
-options.add_argument(f"--user-data-dir={USER_DATA_DIR}")
-options.add_argument(f"--profile-directory={PROFILE_NAME}")
+def critical_tasks_succeeded(task_status: Dict[str, str]) -> bool:
+	"""True only if every gate task ran ('ok') in this run.
 
-driver = webdriver.Edge(options=options)
+	'skipped' counts as failure for critical tasks: silently missing required
+	searches would under-earn points without anyone noticing.
+	"""
+	return all(status == "ok" for status in task_status.values())
 
-mouse = mouse_trajectory.MouseUtils(driver)
-keyboard = mimic_typing.KeyboardUtils(driver)
 
-rewards = rewards_tasks.RewardsTaskUtils(driver)
+def main():
+	parser = argparse.ArgumentParser(description="Automated Microsoft Rewards Farmer with Anti-Detection & LLM Engine")
+	parser.add_argument("--headless", action="store_true", help="Run Edge in headless mode")
+	parser.add_argument("--profile", default=PROFILE_NAME, help=f"Browser profile directory name (default: {PROFILE_NAME})")
+	parser.add_argument("--model", default=DEFAULT_MODEL, help=f"Preferred Ollama model (default: {DEFAULT_MODEL})")
+	parser.add_argument("--no-cooldown", action="store_true", help="Disable the 15-minute search cooldown loop (default: cooldown enabled)")
+	parser.add_argument("--no-mobile", action="store_true", help="Disable Edge Mobile search emulation (default: mobile enabled to farm all points)")
+	parser.add_argument("--debug-cursor", action="store_true", help="Render red tracking cursor (for local visual debugging only)")
+	args = parser.parse_args()
 
-rewards.complete_all_tasks()
+	print("=" * 60)
+	print("  Microsoft Rewards Farmer - Natural Human Emulation")
+	print("=" * 60)
 
-input("Press Enter to exit...")
+	# 1. Pre-flight Ollama LLM check
+	print("\n[PRE-FLIGHT] Checking Ollama LLM service...")
+	resolved_model, is_online = llm_utils.resolve_available_model(args.model)
+	if is_online:
+		print(f"[PRE-FLIGHT] Ollama engine ready with model: {resolved_model}")
+	else:
+		print(f"[PRE-FLIGHT] Ollama offline or unavailable. Operating with intelligent offline query synthesizer.")
 
-driver.quit()
+	# 2. Managed Browser Session with Singleton Lock Protection & Signal Interception
+	print("\n[PRE-FLIGHT] Initializing isolated browser session...")
+	with BrowserManager(user_data_dir=USER_DATA_DIR, profile_name=args.profile, headless=args.headless) as driver:
+		print("[INFO] Browser session started successfully.")
+		
+		# 3. Initialize Rewards UI (navigates to rewards.bing.com/earn and waits for focus/hydration)
+		rewards = rewards_tasks.RewardsTaskUtils(
+			driver,
+			debug_cursor=args.debug_cursor,
+			enable_cooldown=not args.no_cooldown,
+			enable_mobile=not args.no_mobile
+		)
+
+		# 4. Record starting points balance and today's points once the page is loaded
+		tracker = points_tracker.PointsTracker()
+		tracker.record_start(driver)
+
+		# 5. Execute all daily rewards tasks (Daily set, PC searches, Mobile searches, Misc cards, Visual search, Bonus)
+		task_status = rewards.complete_all_tasks()
+
+		# 6. Switch back to earn page, allow generous refresh for Bing telemetry to register points, and record balance
+		rewards.switch_to_earn_page(refresh_wait=6.0)
+		time.sleep(4.0)
+		tracker.record_end(driver)
+
+	if critical_tasks_succeeded(task_status):
+		print("\n[DONE] All scheduled daily tasks finished.")
+	else:
+		print("\n[CRITICAL] A critical task did not complete successfully.")
+		sys.exit(1)
+
+
+if __name__ == "__main__":
+	try:
+		main()
+	except KeyboardInterrupt:
+		print("\n[INFO] Run interrupted by user (KeyboardInterrupt). Exiting cleanly.")
+		sys.exit(130)
+	except Exception as exc:
+		print(f"\n[FATAL] Unhandled error during execution: {exc}")
+		sys.exit(1)

--- a/src/mimic_typing.py
+++ b/src/mimic_typing.py
@@ -1,24 +1,44 @@
+import time
 import random
 from typing import Iterable
 from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.action_chains import ActionChains
 
-FIRST_INTERVAL = (0.0, 0.1)
-SECOND_INTERVAL = (0.1, 0.2)
-THIRD_INTERVAL = (0.2, 0.4)
+FIRST_INTERVAL = (0.05, 0.12)
+SECOND_INTERVAL = (0.12, 0.22)
+THIRD_INTERVAL = (0.22, 0.38)
 
-FIRST_INTERVAL_PROBABILITY = 0.377
-SECOND_INTERVAL_PROBABILITY = 0.5492
-THIRD_INTERVAL_PROBABILITY = 1 - (FIRST_INTERVAL_PROBABILITY + SECOND_INTERVAL_PROBABILITY)
+FIRST_INTERVAL_PROBABILITY = 0.42
+SECOND_INTERVAL_PROBABILITY = 0.48
+THIRD_INTERVAL_PROBABILITY = 1.0 - (FIRST_INTERVAL_PROBABILITY + SECOND_INTERVAL_PROBABILITY)
+
+# Keyboard adjacency mapping for natural typo emulation
+ADJACENT_KEYS = {
+	'a': 'sqwz', 'b': 'vghn', 'c': 'xdfv', 'd': 'serfcx', 'e': 'wsdr',
+	'f': 'drtgvc', 'g': 'ftyhbv', 'h': 'gyujnb', 'i': 'ujko', 'j': 'huikmn',
+	'k': 'jiolm', 'l': 'kop', 'm': 'njk', 'n': 'bhjm', 'o': 'iklp',
+	'p': 'ol', 'q': 'wa', 'r': 'edft', 's': 'awedxz', 't': 'rfgy',
+	'u': 'yhji', 'v': 'cfgb', 'w': 'qase', 'x': 'zsdc', 'y': 'tghu', 'z': 'asx'
+}
 
 class KeyboardUtils:
 	def __init__(self, driver: webdriver.Edge):
 		self.driver = driver
 
-	def send_keys(self, keys: Iterable[str]):
+	def send_keys(self, keys: Iterable[str], allow_typos: bool = True):
 		actions = ActionChains(self.driver, duration=0)
 
 		for key in keys:
+			# Only allow typos on standard lowercase letters with 2.5% chance
+			if allow_typos and isinstance(key, str) and len(key) == 1 and key.lower() in ADJACENT_KEYS and random.random() < 0.025:
+				wrong_key = random.choice(ADJACENT_KEYS[key.lower()])
+				actions.send_keys(wrong_key)
+				# Human realization delay
+				actions.pause(random.uniform(0.18, 0.32))
+				actions.send_keys(Keys.BACK_SPACE)
+				actions.pause(random.uniform(0.08, 0.18))
+
 			actions.send_keys(key)
 
 			interval = random.choices(

--- a/src/mouse_trajectory.py
+++ b/src/mouse_trajectory.py
@@ -217,98 +217,118 @@ def choose_target_in_element(x: int, y: int, height: int, width: int) -> Point:
 	)
 
 class MouseUtils:
-	def __init__(self, driver: webdriver.Edge):
+	def __init__(self, driver: webdriver.Edge, debug_cursor: bool = False):
 		self.driver = driver
-		self.fallback_init_pos = (0, 0) # default fallback position if mouse position is not initialized
+		self.debug_cursor = debug_cursor
+		self.fallback_init_pos = (200, 200) # realistic default position
 		self.reinitialize()
 
 	def reinitialize(self):
 		self.init_driver_with_mouse_tracking()
-		self.init_driver_with_cursor_visualization()
+		if self.debug_cursor:
+			self.init_driver_with_cursor_visualization()
 
 	def init_driver_with_mouse_tracking(self):
 		initial_pos = self.fallback_init_pos
 
 		js_tracker = f"""
-	window.cursorX = {int(initial_pos[0])};
-	window.cursorY = {int(initial_pos[1])};
+	window._trackedCursorX = {int(initial_pos[0])};
+	window._trackedCursorY = {int(initial_pos[1])};
 	document.addEventListener('mousemove', function(event) {{
-		console.log('Mouse moved to: ' + event.clientX + ', ' + event.clientY);
-		window.cursorX = event.clientX;
-		window.cursorY = event.clientY;
-	}});
+		window._trackedCursorX = event.clientX;
+		window._trackedCursorY = event.clientY;
+	}}, {{ passive: true }});
 	"""
-		self.driver.execute_script(js_tracker)
+		try:
+			self.driver.execute_script(js_tracker)
+		except Exception:
+			pass
 
 	def init_driver_with_cursor_visualization(self):
-		cursor_script = """
-	var visualCursor = document.createElement('div');
-	visualCursor.id = 'selenium-visual-cursor';
-	visualCursor.style.position = 'fixed';
-	visualCursor.style.zIndex = '99999';
-	visualCursor.style.width = '15px';
-	visualCursor.style.height = '15px';
-	visualCursor.style.background = 'red';
-	visualCursor.style.borderRadius = '50%';
-	visualCursor.style.border = '2px solid white';
-	visualCursor.style.pointerEvents = 'none'; // Prevents blocking element clicks
-	visualCursor.style.top = '0px';
-	visualCursor.style.left = '0px';
-	visualCursor.style.transition = 'all 0.3s ease;'; // Optional: adds smooth sliding visual
-	document.body.appendChild(visualCursor);
+		if not self.debug_cursor:
+			return
 
-	window.moveVisualCursor = function(x, y) {
-		var cursor = document.getElementById('selenium-visual-cursor');
-		cursor.style.left = x + 'px';
-		cursor.style.top = y + 'px';
-	};
+		cursor_script = """
+	if (!document.getElementById('debug-visual-cursor')) {
+		var visualCursor = document.createElement('div');
+		visualCursor.id = 'debug-visual-cursor';
+		visualCursor.style.position = 'fixed';
+		visualCursor.style.zIndex = '99999';
+		visualCursor.style.width = '12px';
+		visualCursor.style.height = '12px';
+		visualCursor.style.background = 'rgba(230, 50, 50, 0.85)';
+		visualCursor.style.borderRadius = '50%';
+		visualCursor.style.border = '2px solid white';
+		visualCursor.style.pointerEvents = 'none';
+		visualCursor.style.top = '0px';
+		visualCursor.style.left = '0px';
+		visualCursor.style.transition = 'all 0.05s ease';
+		document.body.appendChild(visualCursor);
+
+		window.moveVisualCursor = function(x, y) {
+			var cursor = document.getElementById('debug-visual-cursor');
+			if (cursor) {
+				cursor.style.left = x + 'px';
+				cursor.style.top = y + 'px';
+			}
+		};
+	}
 	"""
-		self.driver.execute_script(cursor_script)
+		try:
+			self.driver.execute_script(cursor_script)
+		except Exception:
+			pass
 
 	def get_current_mouse_position(self) -> Point:
-		pos: dict[str, int] = self.driver.execute_script("return { x: window.cursorX, y: window.cursorY };")
+		try:
+			pos = self.driver.execute_script("return { x: window._trackedCursorX, y: window._trackedCursorY };")
+			if pos and pos.get('x') is not None and pos.get('y') is not None:
+				x, y = int(pos['x']), int(pos['y'])
+				self.fallback_init_pos = (x, y)
+				return (x, y)
+		except Exception:
+			pass
 
-		x, y = pos['x'], pos['y']
+		return self.fallback_init_pos
 
-		if (x, y) == (None, None):
-			self.reinitialize()
-			return self.get_current_mouse_position()
-
-		self.fallback_init_pos = (x, y)
-
-		return (x, y)
-
-	def move_mouse(self, move_time: float, path_function: Callable[[float], Point], visualize: bool=True):
+	def move_mouse(self, move_time: float, path_function: Callable[[float], Point], visualize: bool = False):
 		start_time = time.monotonic()
 		end_time = start_time + move_time
 
 		# The distorted bezier path can overshoot the window edge, which the
 		# driver rejects, so keep every sampled point inside the viewport.
-		viewport = self.driver.execute_script(
-			"return [window.innerWidth, window.innerHeight];"
-		)
-		max_x, max_y = int(viewport[0]) - 2, int(viewport[1]) - 2
+		try:
+			viewport = self.driver.execute_script("return [window.innerWidth, window.innerHeight];")
+			max_x = max(10, int(viewport[0]) - 4) if viewport else 1360
+			max_y = max(10, int(viewport[1]) - 4) if viewport else 760
+		except Exception:
+			max_x, max_y = 1360, 760
 
 		while (current_time := time.monotonic()) < end_time:
 			t = current_time - start_time
 			point = path_function(t)
 
 			point = (
-				min(max(0, point[0]), max_x),
-				min(max(0, point[1]), max_y)
+				min(max(2, int(point[0])), max_x),
+				min(max(2, int(point[1])), max_y)
 			)
 
-			actions = ActionBuilder(self.driver, duration=0)
-			actions.pointer_action.move_to_location(point[0], point[1])
-			actions.perform()
+			try:
+				actions = ActionBuilder(self.driver, duration=0)
+				actions.pointer_action.move_to_location(point[0], point[1])
+				actions.perform()
+				self.fallback_init_pos = point
+			except Exception:
+				pass
 
-			self.fallback_init_pos = point
-
-			if visualize:
-				try: self.driver.execute_script(f"window.moveVisualCursor({point[0]}, {point[1]});")
-				except JavascriptException: # some uninitialization has happened, reinitialize the cursor visualization
+			if visualize and self.debug_cursor:
+				try:
+					self.driver.execute_script(f"if (window.moveVisualCursor) window.moveVisualCursor({point[0]}, {point[1]});")
+				except JavascriptException:
 					self.reinitialize()
-					self.driver.execute_script(f"window.moveVisualCursor({point[0]}, {point[1]});")
+
+			# 60 Hz tick-rate (16ms) to prevent overwhelming WebDriver with HTTP requests
+			time.sleep(0.016)
 
 
 	def wheel_scroll_element_into_view(self, element: WebElement, max_wheel_events: int = 60):
@@ -362,7 +382,39 @@ class MouseUtils:
 
 			time.sleep(random.uniform(0.04, 0.12))
 
-	def move_to_element(self, element: WebElement, visualize: bool=True):
+	def realistic_browse_scroll(self, min_scrolls: int = 2, max_scrolls: int = 4):
+		"""Simulate authentic human browsing scroll behavior on a page.
+
+		Performs natural variable-distance scrolls, interspersed with reading pauses,
+		occasional minor back-scrolls (reading review), and natural deceleration.
+		"""
+		num_scrolls = random.randint(min_scrolls, max_scrolls)
+
+		for i in range(num_scrolls):
+			distance = random.randint(180, 420)
+			steps = random.randint(3, 6)
+
+			for step_idx in range(steps):
+				sub_step = int((distance / steps) * random.uniform(0.7, 1.3))
+				try:
+					ActionChains(self.driver).scroll_by_amount(0, sub_step).perform()
+				except Exception:
+					pass
+				time.sleep(random.uniform(0.02, 0.05))
+
+			# Human reading pause after scroll chunk
+			time.sleep(random.uniform(0.6, 1.8))
+
+			# 25% chance of minor upward correction (re-reading behavior)
+			if random.random() < 0.25:
+				back_distance = random.randint(50, 140)
+				try:
+					ActionChains(self.driver).scroll_by_amount(0, -back_distance).perform()
+				except Exception:
+					pass
+				time.sleep(random.uniform(0.4, 1.0))
+
+	def move_to_element(self, element: WebElement, visualize: bool = False):
 		# The pointer is moved to viewport coordinates, so an element below the
 		# fold yields a target outside the window and the driver rejects the move
 		# with MoveTargetOutOfBoundsException. Bring it into view first, but only

--- a/src/points_tracker.py
+++ b/src/points_tracker.py
@@ -1,0 +1,258 @@
+import os
+import json
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional, Dict, List, Any
+from selenium import webdriver
+
+from constants import USER_DATA_DIR
+import element_selectors
+
+
+HISTORY_FILE = Path(__file__).parent.parent / "points_history.json"
+SUMMARY_FILE = Path(__file__).parent.parent / "points_summary.txt"
+
+
+class PointsTracker:
+	"""Tracks points earned per run, balance history, and produces points_summary.txt."""
+
+	def __init__(self, history_path: Path = HISTORY_FILE, summary_path: Path = SUMMARY_FILE):
+		self.history_path = history_path
+		self.summary_path = summary_path
+		self.start_balance: Optional[int] = None
+		self.end_balance: Optional[int] = None
+		self.start_today_points: Optional[int] = None
+		self.end_today_points: Optional[int] = None
+		self.start_time: Optional[datetime] = None
+
+	@staticmethod
+	def calculate_points_earned(
+		start_balance: Optional[int],
+		end_balance: Optional[int],
+		start_today_points: Optional[int],
+		end_today_points: Optional[int],
+	) -> int:
+		"""Points earned during the run, for history/summary.
+
+		The site's daily "today points" counter is the source of truth: the
+		lifetime balance can lag or freeze on rewards.bing.com, so a balance
+		delta of 0 while today's counter moved must still count as earnings.
+		Falls back to the balance delta only when today's points are unreadable.
+		"""
+		if start_today_points is not None and end_today_points is not None:
+			return max(0, end_today_points - start_today_points)
+		if start_balance is not None and end_balance is not None:
+			return max(0, end_balance - start_balance)
+		if end_today_points is not None:
+			return max(0, end_today_points)
+		return 0
+
+	def load_history(self) -> List[Dict[str, Any]]:
+		if not self.history_path.exists():
+			return []
+		try:
+			data = json.loads(self.history_path.read_text(encoding="utf-8"))
+			if isinstance(data, list):
+				return data
+		except Exception as exc:
+			print(f"[WARNING] Could not parse points history file: {exc}")
+		return []
+
+	def save_history(self, history: List[Dict[str, Any]]):
+		try:
+			self.history_path.write_text(json.dumps(history, indent=2, ensure_ascii=False), encoding="utf-8")
+		except Exception as exc:
+			print(f"[WARNING] Could not write points history file: {exc}")
+
+	def record_start(self, driver: webdriver.Edge) -> Optional[int]:
+		"""Record initial points balance at start of run after page has hydrated."""
+		self.start_time = datetime.now()
+		elements = element_selectors.ElementSelectionUtils(driver)
+		
+		# Allow brief hydration retry
+		for _ in range(3):
+			self.start_balance = elements.get_total_points_balance()
+			self.start_today_points = elements.get_today_points()
+			if self.start_balance is not None:
+				break
+			time.sleep(1.0)
+
+		if self.start_balance is not None:
+			today_str = f" (Today's Points: {self.start_today_points} pts)" if self.start_today_points is not None else ""
+			print(f"[INFO] Initial points balance: {self.start_balance:,} pts{today_str}")
+		else:
+			print("[INFO] Could not read starting points balance from page.")
+		return self.start_balance
+
+	def record_end(self, driver: webdriver.Edge) -> Dict[str, Any]:
+		"""Record final points balance, compute diff, update history and write summary."""
+		end_time = datetime.now()
+		elements = element_selectors.ElementSelectionUtils(driver)
+		
+		# Allow generous hydration retry with refresh fallback
+		for attempt in range(5):
+			self.end_balance = elements.get_total_points_balance()
+			self.end_today_points = elements.get_today_points()
+			if self.end_balance is not None and self.end_today_points is not None:
+				break
+			if attempt == 2:
+				try:
+					driver.refresh()
+					time.sleep(3.0)
+				except Exception:
+					pass
+			time.sleep(1.5)
+
+		history = self.load_history()
+
+		# If start balance was missing, try to use last recorded balance
+		if self.start_balance is None and history:
+			self.start_balance = history[-1].get("end_balance")
+
+		# If end balance is missing, fallback to start balance
+		if self.end_balance is None:
+			self.end_balance = self.start_balance
+
+		earned = self.calculate_points_earned(
+			start_balance=self.start_balance,
+			end_balance=self.end_balance,
+			start_today_points=self.start_today_points,
+			end_today_points=self.end_today_points,
+		)
+
+		entry = {
+			"timestamp": end_time.isoformat(timespec="seconds"),
+			"date": end_time.strftime("%Y-%m-%d %H:%M:%S"),
+			"start_balance": self.start_balance,
+			"end_balance": self.end_balance,
+			"today_points": self.end_today_points,
+			"points_earned": earned,
+		}
+
+		history.append(entry)
+		self.save_history(history)
+		self.update_summary_file(history, current_entry=entry)
+		self.print_summary_to_console(current_entry=entry, history=history)
+
+		return entry
+
+	def _find_closest_historical_balance(
+		self,
+		history: List[Dict[str, Any]],
+		target_days_ago: int,
+		reference_time: datetime,
+	) -> Optional[Dict[str, Any]]:
+		"""Find the recorded entry closest to `target_days_ago` in the past."""
+		if not history:
+			return None
+
+		target_dt = reference_time - timedelta(days=target_days_ago)
+		candidates = []
+
+		for entry in history:
+			ts_str = entry.get("timestamp") or entry.get("date")
+			if not ts_str:
+				continue
+			try:
+				dt = datetime.fromisoformat(ts_str) if "T" in ts_str else datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S")
+			except Exception:
+				continue
+
+			# Must be at or before target date + 1 day tolerance
+			if dt <= target_dt or (target_days_ago == 1 and dt.date() < reference_time.date()):
+				candidates.append((dt, entry))
+
+		if not candidates:
+			return None
+
+		# Pick the one closest to target_dt
+		candidates.sort(key=lambda item: abs((item[0] - target_dt).total_seconds()))
+		return candidates[0][1]
+
+	def generate_summary_text(self, history: List[Dict[str, Any]], current_entry: Optional[Dict[str, Any]] = None) -> str:
+		now = datetime.now()
+		latest = current_entry or (history[-1] if history else {})
+		current_balance = latest.get("end_balance") or 0
+		today_pts = latest.get("today_points")
+		earned_latest = latest.get("points_earned") or 0
+
+		# Look up 1 day, 7 days, 30 days ago
+		entry_1d = self._find_closest_historical_balance(history, target_days_ago=1, reference_time=now)
+		entry_7d = self._find_closest_historical_balance(history, target_days_ago=7, reference_time=now)
+		entry_30d = self._find_closest_historical_balance(history, target_days_ago=30, reference_time=now)
+		first_entry = history[0] if history else None
+
+		def format_comparison(entry: Optional[Dict[str, Any]], label: str) -> str:
+			if not entry or entry.get("end_balance") is None:
+				return f"  {label:<18} : No data recorded yet"
+			past_pts = entry.get("end_balance", 0)
+			past_date = (entry.get("date") or entry.get("timestamp") or "")[:10]
+			diff = current_balance - past_pts
+			diff_str = f"+{diff:,}" if diff >= 0 else f"{diff:,}"
+			return f"  {label:<18} : {past_pts:>8,} pts  ({past_date}) -> {diff_str:>10} pts"
+
+		lines = [
+			"=" * 70,
+			"                  MICROSOFT REWARDS POINTS SUMMARY",
+			"=" * 70,
+			f"  Last Updated : {now.strftime('%Y-%m-%d %H:%M:%S')}",
+			"",
+			"CURRENT BALANCE & RUN EARNINGS",
+			"-" * 70,
+			f"  Current Total Balance : {current_balance:,} points",
+		]
+
+		if today_pts is not None:
+			lines.append(f"  Today's Points Earned : {today_pts:,} points")
+
+		lines.extend([
+			f"  Earned in Latest Run  : +{earned_latest:,} points",
+			"",
+			"HISTORICAL COMPARISONS",
+			"-" * 70,
+			format_comparison(entry_1d, "1 Day Ago"),
+			format_comparison(entry_7d, "1 Week Ago (7d)"),
+			format_comparison(entry_30d, "1 Month Ago (30d)"),
+		])
+
+		if first_entry and first_entry.get("start_balance") is not None:
+			first_pts = first_entry.get("start_balance", 0)
+			first_date = (first_entry.get("date") or first_entry.get("timestamp") or "")[:10]
+			total_gained = current_balance - first_pts
+			total_gained_str = f"+{total_gained:,}" if total_gained >= 0 else f"{total_gained:,}"
+			lines.append(f"  {'All-Time Tracked':<18} : {first_pts:>8,} pts  ({first_date}) -> {total_gained_str:>10} pts gained")
+
+		lines.extend([
+			"",
+			"RECENT RUN HISTORY (Last 10 Runs)",
+			"-" * 70,
+			f"  {'Date & Time':<20} | {'Start Pts':<11} | {'End Pts':<11} | {'Today Pts':<10} | {'Earned'}",
+			"-" * 70,
+		])
+
+		for item in reversed(history[-10:]):
+			dt_str = item.get("date") or item.get("timestamp") or "N/A"
+			s_pts = f"{item.get('start_balance', 0):,}" if item.get('start_balance') is not None else "N/A"
+			e_pts = f"{item.get('end_balance', 0):,}" if item.get('end_balance') is not None else "N/A"
+			t_pts = f"{item.get('today_points', 0):,}" if item.get('today_points') is not None else "-"
+			pts_earned = f"+{item.get('points_earned', 0):,}" if item.get('points_earned') is not None else "N/A"
+			lines.append(f"  {dt_str:<20} | {s_pts:<11} | {e_pts:<11} | {t_pts:<10} | {pts_earned}")
+
+		lines.extend([
+			"=" * 70,
+			""
+		])
+
+		return "\n".join(lines)
+
+	def update_summary_file(self, history: List[Dict[str, Any]], current_entry: Optional[Dict[str, Any]] = None):
+		text = self.generate_summary_text(history, current_entry)
+		try:
+			self.summary_path.write_text(text, encoding="utf-8")
+			print(f"[INFO] Updated points summary file: {self.summary_path.name}")
+		except Exception as exc:
+			print(f"[WARNING] Could not write summary file {self.summary_path}: {exc}")
+
+	def print_summary_to_console(self, current_entry: Dict[str, Any], history: List[Dict[str, Any]]):
+		print("\n" + self.generate_summary_text(history, current_entry))

--- a/src/rewards_tasks.py
+++ b/src/rewards_tasks.py
@@ -1,108 +1,279 @@
 import os
 import random
 import time
-from typing import Callable
+from pathlib import Path
+from typing import Callable, Dict, List, Tuple
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webelement import WebElement
-from selenium.common.exceptions import StaleElementReferenceException, TimeoutException, NoSuchElementException
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.common.exceptions import (
+	StaleElementReferenceException,
+	TimeoutException,
+	NoSuchElementException,
+	WebDriverException,
+)
 import tab_utils
 import llm_utils
 import mouse_trajectory
 import mimic_typing
 import element_selectors
+import app_rewards
+from constants import (
+	REWARDS_EARN_URL,
+	REWARDS_DASHBOARD_URL,
+	BING_BASE_URL,
+	IDLE_DELAY_MIN,
+	IDLE_DELAY_MAX,
+	TASK_PAUSE_MIN,
+	TASK_PAUSE_MAX,
+	VISUAL_SEARCH_IMAGE_PATH,
+	COOLDOWN_BATCH_SIZE,
+	COOLDOWN_SEARCH_DELAY_MIN,
+	COOLDOWN_SEARCH_DELAY_MAX,
+	COOLDOWN_SLEEP_MIN,
+	COOLDOWN_SLEEP_MAX,
+	MAX_COOLDOWN_ROUNDS,
+	MAX_TOTAL_RUNTIME_SECONDS,
+)
 
-VISUAL_SEARCH_IMAGE_PATH = os.path.abspath("visual_search.jpg")
+
+def ensure_visual_search_image() -> str:
+	"""Ensure a valid JPEG image file exists for visual search, generating one if missing."""
+	path = Path(VISUAL_SEARCH_IMAGE_PATH)
+	if not path.exists():
+		try:
+			from PIL import Image
+			img = Image.new("RGB", (200, 200), color=(64, 128, 192))
+			img.save(str(path), format="JPEG")
+			print(f"[INFO] Auto-generated visual search image at: {path.name}")
+		except Exception:
+			try:
+				# Minimal valid 1x1 JPEG bytes fallback
+				minimal_jpg = bytes([
+					0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01,
+					0x01, 0x01, 0x00, 0x48, 0x00, 0x48, 0x00, 0x00, 0xFF, 0xDB, 0x00, 0x43,
+					0x00, 0x08, 0x06, 0x06, 0x07, 0x06, 0x05, 0x08, 0x07, 0x07, 0x07, 0x09,
+					0x09, 0x08, 0x0A, 0x0C, 0x14, 0x0D, 0x0C, 0x0B, 0x0B, 0x0C, 0x19, 0x12,
+					0x13, 0x0F, 0x14, 0x1D, 0x1A, 0x1F, 0x1E, 0x1D, 0x1A, 0x1C, 0x1C, 0x20,
+					0x24, 0x2E, 0x27, 0x20, 0x22, 0x2C, 0x23, 0x1C, 0x1C, 0x28, 0x37, 0x29,
+					0x2C, 0x30, 0x31, 0x34, 0x34, 0x34, 0x1F, 0x27, 0x39, 0x3D, 0x38, 0x32,
+					0x3C, 0x2E, 0x33, 0x34, 0x32, 0xFF, 0xC0, 0x00, 0x0B, 0x08, 0x00, 0x01,
+					0x00, 0x01, 0x01, 0x01, 0x11, 0x00, 0xFF, 0xC4, 0x00, 0x1F, 0x00, 0x00,
+					0x01, 0x05, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+					0x09, 0x0A, 0x0B, 0xFF, 0xDA, 0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x3F,
+					0x00, 0xBF, 0x80, 0xFF, 0xD9
+				])
+				path.write_bytes(minimal_jpg)
+				print(f"[INFO] Created fallback 1x1 JPEG at: {path.name}")
+			except Exception as exc2:
+				print(f"[WARNING] Could not create fallback visual search image: {exc2}")
+	return str(path.resolve())
+
+
+def human_idle_delay(min_s: float = IDLE_DELAY_MIN, max_s: float = IDLE_DELAY_MAX, reason: str = ""):
+	"""Simulate human reading/idle delay with slight randomized variance."""
+	delay = random.uniform(min_s, max_s)
+	if reason:
+		print(f"[INFO] Human pause ({delay:.1f}s) - {reason}")
+	time.sleep(delay)
+
 
 class RewardsTaskUtils:
-	def __init__(self, driver: webdriver.Edge):
+	def __init__(
+		self,
+		driver: webdriver.Edge,
+		debug_cursor: bool = False,
+		enable_cooldown: bool = True,
+		enable_mobile: bool = True
+	):
 		self.driver = driver
+		self.debug_cursor = debug_cursor
+		self.enable_cooldown = enable_cooldown
+		self.enable_mobile = enable_mobile
 
-		self.driver.get("https://rewards.bing.com/")
+		self.driver.get(REWARDS_EARN_URL)
+		element_selectors.dismiss_cookie_and_consent_banners(self.driver)
 
 		self.tab_utils = tab_utils.TabUtils(driver)
 		self.tab_utils.ensure_focus()
 
-		self.mouse = mouse_trajectory.MouseUtils(driver)
+		self.mouse = mouse_trajectory.MouseUtils(driver, debug_cursor=debug_cursor)
 		self.keyboard = mimic_typing.KeyboardUtils(driver)
 		self.elements = element_selectors.ElementSelectionUtils(driver)
 
-	def find_element(self, xpath: str):
+	def find_element(self, xpath: str) -> WebElement:
 		return self.driver.find_element(By.XPATH, xpath)
 
-	def wait_for_element(self, element_getter: Callable[[], WebElement | list[WebElement]], timeout: int = 10) -> WebElement | list[WebElement]:
+	def wait_for_element(self, element_getter: Callable[[], WebElement | list[WebElement]], timeout: int = 15) -> WebElement | list[WebElement]:
 		def condition(_: webdriver.Edge):
 			try:
 				element_or_elements = element_getter()
-
 				return element_or_elements
-			except:
+			except (NoSuchElementException, StaleElementReferenceException):
+				return False
+			except Exception:
 				return False
 
 		return WebDriverWait(self.driver, timeout).until(condition)
 
-	def switch_to_earn_page(self):
-		self.move_to_and_click(self.elements.get_earn_tab())
+	def switch_to_earn_page(self, refresh_wait: float = 0.0):
+		element_selectors.dismiss_cookie_and_consent_banners(self.driver)
+		curr = self.driver.current_url or ""
+		if "rewards.bing.com/earn" not in curr:
+			self.driver.get(REWARDS_EARN_URL)
+			self.tab_utils.ensure_focus()
+		else:
+			try:
+				earn_tab = self.elements.get_earn_tab()
+				self.move_to_and_click(earn_tab)
+			except Exception:
+				self.driver.get(REWARDS_EARN_URL)
+				self.tab_utils.ensure_focus()
+
+		if refresh_wait > 0:
+			time.sleep(refresh_wait)
+			try:
+				self.driver.refresh()
+				time.sleep(2.5)
+			except Exception:
+				pass
+
+		element_selectors.dismiss_cookie_and_consent_banners(self.driver)
 
 	def switch_to_dashboard(self):
-		self.move_to_and_click(self.elements.get_dashboard_tab())
+		element_selectors.dismiss_cookie_and_consent_banners(self.driver)
+		try:
+			dash_tab = self.elements.get_dashboard_tab()
+			self.move_to_and_click(dash_tab)
+		except Exception:
+			self.driver.get(REWARDS_DASHBOARD_URL)
+			self.tab_utils.ensure_focus()
+		element_selectors.dismiss_cookie_and_consent_banners(self.driver)
 
 	def move_to_and_click(self, elem: WebElement):
 		self.mouse.move_to_element(elem)
+		time.sleep(random.uniform(0.1, 0.3))
 		self.mouse.human_like_click()
 
-	def wait_for_then_click(self, element_getter: Callable[[], WebElement], timeout: int = 10):
+	def wait_for_then_click(self, element_getter: Callable[[], WebElement], timeout: int = 15):
 		elem = self.wait_for_element(element_getter, timeout)
 		self.move_to_and_click(elem)
 
+	# ------------------------------------------------------------------
+	# Interactive Quiz / Poll Answering
+	# ------------------------------------------------------------------
+
+	def attempt_solve_quiz_or_poll(self, max_attempts: int = 6):
+		"""Detect and complete interactive Daily Set activities (Supersonic, This or That, Daily Poll)."""
+		quiz_selectors = [
+			# Poll choices
+			".btOption",
+			"[id*='btoption' i]",
+			"[role='radio']",
+			# Supersonic / Lightspeed quiz choices
+			".rqOption",
+			"[role='button'][id*='choice' i]",
+			"[class*='rqOption' i]",
+			"input[type='button'][value*='choice' i]",
+			"div[id*='QuestionPane' i] [role='button']",
+			# This or That cards
+			"div[id*='choice' i] img",
+			"div[id*='choice' i]",
+		]
+
+		for attempt in range(max_attempts):
+			element_selectors.dismiss_cookie_and_consent_banners(self.driver)
+			options = []
+			for selector in quiz_selectors:
+				try:
+					found = self.driver.find_elements(By.CSS_SELECTOR, selector)
+					visible = [el for el in found if el.is_displayed()]
+					if visible:
+						options = visible
+						break
+				except Exception:
+					continue
+
+			if not options:
+				break
+
+			target = random.choice(options)
+			try:
+				self.move_to_and_click(target)
+				print(f"[INFO] Daily set interactive click ({attempt + 1}/{max_attempts})")
+			except Exception:
+				try:
+					self.driver.execute_script("arguments[0].click();", target)
+				except Exception:
+					break
+
+			time.sleep(random.uniform(2.0, 3.5))
+
+			# Check if there is a 'Next Question' or 'Continue' button
+			next_btns = self.driver.find_elements(
+				By.CSS_SELECTOR,
+				"input[type='submit'][value*='Next' i], button[id*='next' i], .rqNext, input[value*='Fortsätt' i], input[value*='Nästa' i]"
+			)
+			for nb in next_btns:
+				if nb.is_displayed():
+					try:
+						self.move_to_and_click(nb)
+						time.sleep(random.uniform(1.5, 2.5))
+					except Exception:
+						pass
+					break
+
+	# ------------------------------------------------------------------
+	# Task: Bing Daily Set
+	# ------------------------------------------------------------------
+
 	def complete_bing_daily_set(self, expected_activities: int = 3):
 		self.switch_to_earn_page()
-
 		self.wait_for_then_click(self.elements.get_open_daily_set_button)
 
-		# The panel hydrates progressively, so the first non-empty snapshot can
-		# hold fewer than 3 activities. wait_for_element returns on the first
-		# truthy result, so a 1-element list satisfied it and indexing [1] and
-		# [2] then raised IndexError, taking the whole task down. Wait for the
-		# full set instead, and if it never fills, work with what is there.
 		def full_activity_list():
 			activities = self.elements.get_daily_set_elements()
-
 			return activities if len(activities) >= expected_activities else False
 
 		try:
-			daily_set_links = self.wait_for_element(full_activity_list, timeout=30)
+			daily_set_links = self.wait_for_element(full_activity_list, timeout=25)
 		except TimeoutException:
 			daily_set_links = self.elements.get_daily_set_elements()
-
 			print(f"[WARNING] Daily set panel only shows {len(daily_set_links)} of {expected_activities} activities")
 
-		# Re-read the panel per index: clicking an activity can re-render it and
-		# stale the captured references.
 		for index in range(len(daily_set_links)):
 			activities = self.elements.get_daily_set_elements()
-
 			if index >= len(activities):
 				break
 
 			self.move_to_and_click(activities[index])
-			time.sleep(random.uniform(2, 3))
-			self.driver.switch_to.window(self.driver.current_window_handle) # refocus on the main tab
+			time.sleep(random.uniform(2.0, 3.0))
+
+			# Switch to opened activity tab and dismiss cookies
+			self.tab_utils.switch_to_other_tab()
+			element_selectors.dismiss_cookie_and_consent_banners(self.driver)
+
+			# Attempt quiz or poll completion if applicable
+			self.attempt_solve_quiz_or_poll()
+
+			time.sleep(random.uniform(1.5, 2.5))
+			self.tab_utils.close_all_other_tabs()
 
 		self.tab_utils.close_all_other_tabs()
 
+	# ------------------------------------------------------------------
+	# Task: Explore on Bing
+	# ------------------------------------------------------------------
+
 	def complete_explore_on_bing_tasks(self):
 		self.switch_to_earn_page()
-
 		explore_on_bing_links = self.elements.get_explore_on_bing_elements()
 
 		if not explore_on_bing_links:
-			# Raise rather than return, so complete_all_tasks reports this as
-			# [SKIP]. Returning quietly made it print [OK] for a task that never
-			# ran, which is exactly the kind of false success a scheduled run
-			# must not produce.
 			raise NoSuchElementException("no Explore on Bing section in this UI variant")
 
 		for card in explore_on_bing_links:
@@ -111,112 +282,153 @@ class RewardsTaskUtils:
 
 			self.move_to_and_click(card)
 			self.tab_utils.switch_to_other_tab()
+			element_selectors.dismiss_cookie_and_consent_banners(self.driver)
 
 			self.wait_for_element(self.elements.get_bing_search_bar)
+			# Natural human search query WITHOUT static -noai suffix
+			self.keyboard.send_keys(f"{query}{Keys.ENTER}")
 
-			# search bar should be auto-focused
-
-			self.keyboard.send_keys(f"{query} -noai{Keys.ENTER}")
-
-			time.sleep(random.uniform(2, 3))
+			# Simulate reading and browsing result
+			time.sleep(random.uniform(2.0, 3.5))
+			self.mouse.realistic_browse_scroll(min_scrolls=1, max_scrolls=2)
 
 			self.tab_utils.switch_to_other_tab()
 			self.tab_utils.close_all_other_tabs()
 
-		time.sleep(random.uniform(1, 2)) # allow card statuses to update
+		time.sleep(random.uniform(1.5, 2.5))
 
 		for card in explore_on_bing_links:
 			if not self.elements.card_is_complete(card):
-				print(f"[WARNING] Explore on Bing Card [desc={self.elements.extract_card_descriptions(card)!r}] is not complete after searching. Please check manually.")
+				print(f"[WARNING] Explore on Bing Card [desc={self.elements.extract_card_descriptions(card)!r}] not complete after searching.")
+
+	# ------------------------------------------------------------------
+	# Task: Visual Search
+	# ------------------------------------------------------------------
 
 	def complete_visual_search(self):
 		self.switch_to_earn_page()
+		try:
+			btn = self.elements.get_open_visual_search_sidebar()
+		except NoSuchElementException:
+			raise NoSuchElementException("Visual Search streak is not in today's active streak set")
 
-		self.wait_for_then_click(self.elements.get_open_visual_search_sidebar)
-
+		self.move_to_and_click(btn)
 		self.wait_for_then_click(self.elements.get_search_now_link_from_visual_search_sidebar)
 
 		self.tab_utils.switch_to_other_tab()
+		element_selectors.dismiss_cookie_and_consent_banners(self.driver)
 
 		self.wait_for_then_click(self.elements.get_visual_search_button)
-
 		file_input = self.wait_for_element(self.elements.get_visual_search_file_input)
+		
+		# Ensure image exists before sending keys
+		valid_img_path = ensure_visual_search_image()
+		file_input.send_keys(valid_img_path)
 
-		file_input.send_keys(VISUAL_SEARCH_IMAGE_PATH)
-
-		time.sleep(random.uniform(3, 5))
-
+		time.sleep(random.uniform(3.5, 5.5))
 		self.tab_utils.switch_to_other_tab()
 		self.tab_utils.close_all_other_tabs()
 
+	# ------------------------------------------------------------------
+	# Task: Misc Cards & Activities
+	# ------------------------------------------------------------------
+
 	def complete_misc_cards(self):
 		self.switch_to_earn_page()
+		try:
+			misc_cards = self.elements.get_all_misc_cards()
+		except Exception:
+			misc_cards = []
 
-		misc_cards: list[WebElement] = self.wait_for_element(self.elements.get_all_misc_cards)
+		if not misc_cards:
+			print("[INFO] No extra activity cards found in this UI variant.")
+			return
 
-		for card in misc_cards:
+		uncompleted = [
+			card for card in misc_cards
+			if not self.elements.card_is_complete(card) and self.elements.get_card_point_value(card) > 0
+		]
+
+		if not uncompleted:
+			print("[INFO] All misc activity cards are already completed.")
+			return
+
+		for card in uncompleted:
 			self.mouse.wheel_scroll_element_into_view(card)
 
 			if not self.elements.card_is_complete(card) and self.elements.get_card_point_value(card) > 0:
 				self.move_to_and_click(card)
-				time.sleep(random.uniform(1, 2))
+				time.sleep(random.uniform(1.8, 3.2))
 				self.driver.switch_to.window(self.driver.current_window_handle)
 
-		for card in misc_cards:
+		for card in uncompleted:
 			if not self.elements.card_is_complete(card) and self.elements.get_card_point_value(card) > 0:
-				print(f"[WARNING] Misc Card [desc={self.elements.extract_card_descriptions(card)!r}] is not complete after clicking. Please check manually.")
+				print(f"[WARNING] Misc Card [desc={self.elements.extract_card_descriptions(card)!r}] not complete after clicking.")
 
 		self.tab_utils.close_all_other_tabs()
-
 		self.mouse.wheel_scroll_to_top()
 
-	def complete_required_searches(self, max_rounds: int = 6):
-		# Points per search are not fixed. Some markets award 3 rather than 5,
-		# the daily maximum itself changes (observed 15, 30 and 60 on the same
-		# account within one day, with the counter resetting), and daily set and
-		# card searches count towards the same quota. A single up front division
-		# therefore leaves points on the table and still reports success.
-		# Measure, search, measure again.
-		points_earned, max_pts = self.read_search_points()
 
+	# ------------------------------------------------------------------
+	# Task: Required Daily Searches with Adaptive 15-Minute Cooldown Loop
+	# ------------------------------------------------------------------
+
+	def complete_required_searches(self, max_rounds: int = MAX_COOLDOWN_ROUNDS):
+		start_timestamp = time.time()
+		points_earned, max_pts = self.read_search_points()
 		print(f"[INFO] Search points before: {points_earned}/{max_pts}")
 
-		for round_number in range(1, max_rounds + 1):
-			if points_earned >= max_pts:
+		if points_earned >= max_pts:
+			print(f"[OK] Search quota complete: {points_earned}/{max_pts}")
+			return
+
+		round_number = 0
+		while points_earned < max_pts and round_number < max_rounds:
+			round_number += 1
+			elapsed_s = time.time() - start_timestamp
+			if elapsed_s > MAX_TOTAL_RUNTIME_SECONDS:
+				print(f"[WARNING] Safety limit reached ({elapsed_s / 60:.1f}m runtime). Ending search loop.")
 				break
 
-			# Assume the lower known rate so a round never overshoots by much.
-			searches = max(1, (max_pts - points_earned) // 3)
+			remaining = max_pts - points_earned
+			needed_searches = max(1, remaining // 3)
+			batch_count = min(COOLDOWN_BATCH_SIZE, needed_searches)
 
-			self.run_search_batch(searches)
+			print(f"\n[INFO] --- Search Batch {round_number}/{max_rounds} (Target: {batch_count} searches) ---")
+			self.run_search_batch(batch_count)
+
+			# Give Bing's points telemetry a moment to settle
+			time.sleep(random.uniform(4.0, 6.0))
 
 			previous = points_earned
 			points_earned, max_pts = self.read_search_points()
+			diff = points_earned - previous
+			print(f"[INFO] Batch {round_number} complete -> {points_earned}/{max_pts} (gained +{diff} pts)")
 
-			print(f"[INFO] Round {round_number}: {searches} searches -> {points_earned}/{max_pts}")
-
-			if points_earned <= previous:
-				print("[WARNING] Round produced no points, stopping instead of searching pointlessly.")
+			if points_earned >= max_pts:
 				break
 
+			# If more points are needed, execute cooldown pause to bypass 15-minute search throttling
+			if self.enable_cooldown and round_number < max_rounds:
+				cooldown_sec = random.uniform(COOLDOWN_SLEEP_MIN, COOLDOWN_SLEEP_MAX)
+				cooldown_min = cooldown_sec / 60.0
+				print(f"[INFO] Cooldown pause ({cooldown_min:.1f}m) until next search batch ({points_earned}/{max_pts} pts)...")
+				time.sleep(cooldown_sec)
+			else:
+				time.sleep(random.uniform(6.0, 12.0))
+
 		if points_earned < max_pts:
-			print(f"[WARNING] Search quota not filled: {points_earned}/{max_pts}")
+			print(f"[WARNING] Search quota incomplete: {points_earned}/{max_pts}")
 		else:
-			print(f"Search quota complete: {points_earned}/{max_pts}")
+			print(f"[OK] Search quota complete: {points_earned}/{max_pts}")
 
-	def read_search_points(self):
-		"""Open the points breakdown, read the Bing search row, close it again."""
+	def read_search_points(self, search_type: str = "pc") -> Tuple[int, int]:
+		"""Open points breakdown sidebar, read Bing search fraction, close panel."""
 		self.switch_to_earn_page()
-
-		# 30s rather than the default 10s: this runs after the earlier tasks have
-		# navigated away, so the earn page re-renders from scratch first and the
-		# breakdown button regularly needs longer than 10s to appear. Timing out
-		# here skipped the entire search task while points were still available.
 		self.wait_for_then_click(self.elements.get_points_breakdown_button, timeout=30)
 
 		close_btn = self.wait_for_element(self.elements.get_close_button_on_points_breakdown, timeout=15)
-
-		points_earned, max_pts = self.elements.get_points_earned_from_searches_on_points_breakdown()
+		points_earned, max_pts = self.elements.get_points_earned_from_searches_on_points_breakdown(search_type=search_type)
 
 		try:
 			self.move_to_and_click(close_btn)
@@ -225,65 +437,253 @@ class RewardsTaskUtils:
 
 		return points_earned, max_pts
 
+	def enable_mobile_emulation(self):
+		"""Dynamically switch browser session to Edge Mobile view and UA via CDP."""
+		from constants import MOBILE_UA
+		try:
+			self.driver.execute_cdp_cmd("Network.setUserAgentOverride", {
+				"userAgent": MOBILE_UA,
+				"platform": "iPhone"
+			})
+			self.driver.execute_cdp_cmd("Emulation.setDeviceMetricsOverride", {
+				"width": 393,
+				"height": 852,
+				"deviceScaleFactor": 3,
+				"mobile": True
+			})
+			self.driver.execute_cdp_cmd("Emulation.setTouchEmulationEnabled", {
+				"enabled": True,
+				"maxTouchPoints": 5
+			})
+			print("[INFO] Enabled Edge Mobile device emulation via CDP.")
+		except Exception as exc:
+			print(f"[WARNING] Could not enable mobile CDP emulation: {exc}")
+
+	def disable_mobile_emulation(self):
+		"""Restore desktop browser session and UA via CDP."""
+		from constants import WINDOWS_DESKTOP_UA
+		try:
+			self.driver.execute_cdp_cmd("Network.setUserAgentOverride", {
+				"userAgent": WINDOWS_DESKTOP_UA,
+				"platform": "Win32"
+			})
+			self.driver.execute_cdp_cmd("Emulation.setDeviceMetricsOverride", {
+				"width": 1366,
+				"height": 768,
+				"deviceScaleFactor": 1,
+				"mobile": False
+			})
+			self.driver.execute_cdp_cmd("Emulation.setTouchEmulationEnabled", {
+				"enabled": False
+			})
+			print("[INFO] Restored Desktop emulation via CDP.")
+		except Exception as exc:
+			print(f"[WARNING] Could not restore desktop CDP emulation: {exc}")
+
+	def complete_mobile_searches(self, max_rounds: int = MAX_COOLDOWN_ROUNDS):
+		"""Farm mobile search points using Edge Mobile device emulation."""
+		print("\n[INFO] --- Checking Mobile Rewards Quota ---")
+		try:
+			points_earned, max_pts = self.read_search_points(search_type="mobile")
+		except NoSuchElementException:
+			print("[SKIP] Mobile searches: mobile search quota not unlocked on this account level (Level 2 required).")
+			return
+		except Exception as exc:
+			print(f"[SKIP] Mobile searches: could not read mobile quota ({exc})")
+			return
+
+		print(f"[INFO] Mobile search points before: {points_earned}/{max_pts}")
+
+		if points_earned >= max_pts:
+			print(f"[OK] Mobile search quota complete: {points_earned}/{max_pts}")
+			return
+
+		self.enable_mobile_emulation()
+		try:
+			time.sleep(1.5)
+
+			start_timestamp = time.time()
+			round_number = 0
+			while points_earned < max_pts and round_number < max_rounds:
+				round_number += 1
+				elapsed_s = time.time() - start_timestamp
+				if elapsed_s > MAX_TOTAL_RUNTIME_SECONDS:
+					print(f"[WARNING] Safety limit reached during mobile searches ({elapsed_s / 60:.1f}m).")
+					break
+
+				remaining = max_pts - points_earned
+				needed_searches = max(1, remaining // 3)
+				batch_count = min(COOLDOWN_BATCH_SIZE, needed_searches)
+
+				print(f"\n[INFO] --- Mobile Search Batch {round_number}/{max_rounds} (Target: {batch_count} searches) ---")
+				self.run_search_batch(batch_count)
+
+				time.sleep(random.uniform(4.0, 6.0))
+				previous = points_earned
+				points_earned, max_pts = self.read_search_points(search_type="mobile")
+				diff = points_earned - previous
+				print(f"[INFO] Mobile Batch {round_number} complete -> {points_earned}/{max_pts} (gained +{diff} pts)")
+
+				if points_earned >= max_pts:
+					break
+
+				if self.enable_cooldown and round_number < max_rounds:
+					cooldown_sec = random.uniform(COOLDOWN_SLEEP_MIN, COOLDOWN_SLEEP_MAX)
+					cooldown_min = cooldown_sec / 60.0
+					print(f"[INFO] Cooldown pause ({cooldown_min:.1f}m) until next mobile search batch ({points_earned}/{max_pts} pts)...")
+					time.sleep(cooldown_sec)
+				else:
+					time.sleep(random.uniform(6.0, 12.0))
+
+			if points_earned < max_pts:
+				print(f"[WARNING] Mobile search quota incomplete: {points_earned}/{max_pts}")
+			else:
+				print(f"[OK] Mobile search quota complete: {points_earned}/{max_pts}")
+		finally:
+			self.disable_mobile_emulation()
+
 	def run_search_batch(self, count: int):
-		self.driver.get("https://www.bing.com/")
+		self.driver.get(BING_BASE_URL)
 		self.tab_utils.ensure_focus()
+		element_selectors.dismiss_cookie_and_consent_banners(self.driver)
 
 		self.wait_for_element(self.elements.get_bing_search_bar)
 
-		# search bar should be auto-focused
+		seed_word = llm_utils.get_random_noun()
+		queries = list(llm_utils.get_related_search_queries(seed_word, num_queries=count))
 
-		for i, query in enumerate(
-			llm_utils.get_related_search_queries(
-				llm_utils.get_random_noun(), num_queries=count
-			)
-		):
-			self.keyboard.send_keys(f"{query} -noai{Keys.ENTER}")
+		for i, query in enumerate(queries, start=1):
+			print(f"[INFO] Search [{i}/{len(queries)}]: '{query}'")
+			# Natural human search query WITHOUT static -noai suffix
+			self.keyboard.send_keys(f"{query}{Keys.ENTER}")
 
-			time.sleep(random.uniform(0.5, 1))
+			# Natural pause and realistic viewport browsing scroll
+			time.sleep(random.uniform(2.5, 4.0))
+			self.mouse.realistic_browse_scroll(min_scrolls=1, max_scrolls=2)
 
-			try: self.wait_for_then_click(self.elements.get_clear_bing_search_query_button)
-			except StaleElementReferenceException:
-				print(f"[WARNING] StaleElementReferenceException when trying to click the clear button for query {i+1}. Trying again...")
+			# 20% chance of clicking an organic search result (CTR simulation)
+			if random.random() < 0.20:
+				try:
+					results = self.driver.find_elements(By.CSS_SELECTOR, "li.b_algo h2 a, #b_results h2 a")
+					visible_results = [r for r in results if r.is_displayed()]
+					if visible_results:
+						target_link = random.choice(visible_results[:3])
+						self.mouse.move_to_element(target_link, visualize=self.debug_cursor)
+						time.sleep(random.uniform(0.2, 0.4))
+						target_link.click()
+						# Read / browse page for 4 to 6.5 seconds
+						time.sleep(random.uniform(4.0, 6.5))
+						self.mouse.realistic_browse_scroll(min_scrolls=1, max_scrolls=2)
+						self.driver.back()
+						self.tab_utils.ensure_focus()
+						time.sleep(random.uniform(1.5, 2.5))
+				except Exception:
+					pass
+
+			# Clear search input for next query
+			try:
 				self.wait_for_then_click(self.elements.get_clear_bing_search_query_button)
+			except StaleElementReferenceException:
+				self.wait_for_then_click(self.elements.get_clear_bing_search_query_button)
+			except (NoSuchElementException, TimeoutException):
+				# Fallback: re-select search bar and clear
+				bar = self.elements.get_bing_search_bar()
+				bar.clear()
 
-		self.driver.get("https://rewards.bing.com/")
+			# Human delay between individual searches
+			delay = random.uniform(COOLDOWN_SEARCH_DELAY_MIN, COOLDOWN_SEARCH_DELAY_MAX)
+			time.sleep(delay)
+
+		self.driver.get(REWARDS_EARN_URL)
 		self.tab_utils.ensure_focus()
+
+	# ------------------------------------------------------------------
+	# Task: Bonus Points
+	# ------------------------------------------------------------------
 
 	def claim_bonus_points(self):
 		self.switch_to_dashboard()
-
 		self.wait_for_then_click(self.elements.get_bonus_button_on_dashboard)
 
 		try:
 			self.wait_for_then_click(self.elements.get_claim_bonus_points_button)
 		except TimeoutException:
-			print("[WARNING] Could not find the 'Claim Bonus Points' button. There are likely no bonus points to claim at this time.")
+			print("[INFO] No bonus points button to claim at this time.")
 
-	def complete_all_tasks(self):
-		# Each task is run independently. The Rewards UI differs by market and
-		# changes between deploys, so a task the current variant does not ship
-		# must not take the remaining ones down with it.
-		steps = (
+	# ------------------------------------------------------------------
+	# Task: Read to Earn (Bing / Start App News Articles)
+	# ------------------------------------------------------------------
+
+	def complete_read_to_earn(self):
+		"""Complete Read to Earn news articles (+30 points) via Bing App API or MSN browsing."""
+		print("\n[INFO] --- Starting Read to Earn News Task ---")
+		token = app_rewards.get_mobile_app_access_token(self.driver)
+		if token:
+			count = app_rewards.execute_read_to_earn_api(token, max_articles=10)
+			print(f"[OK] Read to Earn ({count}/10 articles read)")
+			# Also attempt Mobile App Daily Check-In while authenticated
+			app_rewards.execute_daily_checkin_api(token)
+		else:
+			self.enable_mobile_emulation()
+			try:
+				app_rewards.browse_msn_news_fallback(self.driver, count=6)
+				print("[OK] Read to Earn (MSN browser fallback)")
+			finally:
+				self.disable_mobile_emulation()
+
+	# ------------------------------------------------------------------
+	# Main Orchestration with Randomized Task Execution Order
+	# ------------------------------------------------------------------
+
+	def complete_all_tasks(self) -> Dict[str, str]:
+		"""Execute daily rewards tasks in a randomized order with human reading pauses.
+
+		Returns per-task status: 'ok', 'skipped' (element not in this UI
+		variant) or 'failed: <ExcType>: <msg>' — consumed by
+		critical_tasks_succeeded() in main.py for the process exit code.
+		"""
+		available_tasks: List[Tuple[str, Callable[[], None]]] = [
+			("Required searches", self.complete_required_searches),
 			("Bing daily set", self.complete_bing_daily_set),
 			("Explore on Bing", self.complete_explore_on_bing_tasks),
 			("Visual search", self.complete_visual_search),
 			("Misc cards", self.complete_misc_cards),
-			("Required searches", self.complete_required_searches),
 			("Bonus points", self.claim_bonus_points),
-		)
+		]
 
-		for name, step in steps:
+		if self.enable_mobile:
+			available_tasks.append(("Mobile searches", self.complete_mobile_searches))
+			available_tasks.append(("Read to Earn", self.complete_read_to_earn))
+
+		# Required searches always run first (critical daily earner); shuffle
+		# only the remaining tasks to emulate human unpredictability.
+		rest = available_tasks[1:]
+		random.shuffle(rest)
+		available_tasks = [available_tasks[0]] + rest
+		order_names = " -> ".join(name for name, _ in available_tasks)
+		print(f"\n[INFO] Randomized task execution plan:\n       {order_names}\n")
+
+		task_status: Dict[str, str] = {}
+		for index, (name, task_fn) in enumerate(available_tasks, start=1):
+			print(f"--- Task [{index}/{len(available_tasks)}]: {name} ---")
 			try:
-				step()
+				task_fn()
 				print(f"[OK] {name}")
+				task_status[name] = "ok"
 			except (NoSuchElementException, TimeoutException) as exc:
 				print(f"[SKIP] {name}: not available in this UI variant ({type(exc).__name__})")
+				task_status[name] = "skipped"
 			except Exception as exc:
 				print(f"[FAIL] {name}: {type(exc).__name__}: {exc}")
+				task_status[name] = f"failed: {type(exc).__name__}: {exc}"
 
-			# Leave a clean tab state behind for the next task.
+			# Clean tabs state and insert realistic human pause between tasks
 			try:
 				self.tab_utils.close_all_other_tabs()
 			except Exception:
 				pass
+
+			if index < len(available_tasks):
+				human_idle_delay(TASK_PAUSE_MIN, TASK_PAUSE_MAX, reason=f"between tasks ({name})")
+
+		return task_status

--- a/src/tab_utils.py
+++ b/src/tab_utils.py
@@ -1,10 +1,10 @@
 from selenium.common.exceptions import WebDriverException, JavascriptException
 from selenium import webdriver
 
-GHOST_TAB_URLS = (
-	"https://ntp.msn.com/edge/ntp?locale=en-US&title=New%20tab&fre=1&dsp=1&sp=Bing&feed_dis=always&en_widget_reg=false&prerender=1&PC=U531", # has fre
-	"https://ntp.msn.com/edge/ntp?locale=en-US&title=New%20tab&dsp=1&sp=Bing&feed_dis=always&en_widget_reg=false&prerender=1&PC=U531" # no fre
-)
+
+def is_ghost_tab(url: str) -> bool:
+	return "ntp.msn.com" in url or "newtab" in url or "chrome://" in url or "edge://" in url
+
 
 class TabUtils:
 	def __init__(self, driver: webdriver.Edge):
@@ -12,53 +12,55 @@ class TabUtils:
 		self.problematic_tabs = set()
 
 	def ensure_focus(self):
+		"""Ensure window/tab has focus using CDP protocol without monkey-patching native DOM prototypes."""
 		try:
-			self.driver.execute_script("""
-Object.defineProperty(document, 'hidden', { get: () => false });
-Object.defineProperty(document, 'visibilityState', { get: () => 'visible' });
-Document.prototype.hasFocus = function() { return true; };
-window.hasFocus = function() { return true; };
-document.dispatchEvent(new Event('visibilitychange'));
-""")
-		except JavascriptException: pass # it's probably a property redef exc
+			self.driver.execute_cdp_cmd("Emulation.setFocusEmulationEnabled", {"enabled": True})
+			self.driver.execute_cdp_cmd("Page.bringToFront", {})
+		except Exception:
+			pass
+
+	def get_rewards_tab_handle(self) -> str:
+		"""Find the window handle that contains rewards.bing.com."""
+		for handle in self.driver.window_handles:
+			try:
+				self.driver.switch_to.window(handle)
+				if "rewards.bing.com" in (self.driver.current_url or ""):
+					return handle
+			except Exception:
+				pass
+		return self.driver.window_handles[0] if self.driver.window_handles else ""
 
 	def switch_to_other_tab(self):
+		"""Switch to the most recently opened tab that isn't the current or ghost tab."""
 		current_window = self.driver.current_window_handle
-
-		for handle in self.driver.window_handles:
+		for handle in reversed(self.driver.window_handles):
 			if handle != current_window and handle not in self.problematic_tabs:
-				self.driver.switch_to.window(handle)
-
-				if self.driver.current_url in GHOST_TAB_URLS:
-					print(f"[INFO] Found ghost tab with handle {handle} and URL {self.driver.current_url}.")
-					continue
-
-				self.ensure_focus()
-				return
-
-	def close_all_other_tabs(self, exceptions: list[str] = None):
-		if exceptions is None:
-			exceptions = [self.driver.current_window_handle]
-
-		switch_back_to = exceptions[0]
-
-		for handle in self.driver.window_handles:
-			if handle not in exceptions and handle not in self.problematic_tabs:
-				self.driver.switch_to.window(handle)
-
-				if self.driver.current_url in GHOST_TAB_URLS:
-					print(f"[INFO] Found ghost tab with handle {handle} and URL {self.driver.current_url}, not closing.")
-					continue
-
-				tab_url = self.driver.current_url
-
 				try:
-					self.driver.close()
-					print(f"[INFO] Closed tab with handle {handle} and URL {tab_url}.")
-
+					self.driver.switch_to.window(handle)
+					if is_ghost_tab(self.driver.current_url or ""):
+						continue
+					self.ensure_focus()
+					return
 				except WebDriverException:
-					print(f"[WARNING] Could not close tab with handle {handle} and URL {tab_url}.")
-					self.problematic_tabs.add(handle)
-					pass
+					continue
 
-		self.driver.switch_to.window(switch_back_to)
+	def close_all_other_tabs(self, exceptions: list = None):
+		"""Close all opened secondary tabs and ghost tabs, keeping only the main Rewards tab."""
+		rewards_handle = self.get_rewards_tab_handle()
+		
+		for handle in list(self.driver.window_handles):
+			if handle != rewards_handle and len(self.driver.window_handles) > 1:
+				try:
+					self.driver.switch_to.window(handle)
+					tab_url = self.driver.current_url
+					self.driver.close()
+					print(f"[INFO] Closed extra tab: {tab_url}")
+				except WebDriverException:
+					self.problematic_tabs.add(handle)
+
+		if rewards_handle in self.driver.window_handles:
+			self.driver.switch_to.window(rewards_handle)
+			self.ensure_focus()
+		elif self.driver.window_handles:
+			self.driver.switch_to.window(self.driver.window_handles[0])
+			self.ensure_focus()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,19 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import main
+
+
+class CriticalTaskStatusTests(unittest.TestCase):
+    def test_required_search_skip_is_not_success(self):
+        self.assertFalse(main.critical_tasks_succeeded({"Required searches": "skipped"}))
+
+    def test_required_search_success_is_success(self):
+        self.assertTrue(main.critical_tasks_succeeded({"Required searches": "ok"}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_points_tracker.py
+++ b/tests/test_points_tracker.py
@@ -1,0 +1,33 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from points_tracker import PointsTracker
+
+
+class PointsEarnedCalculationTests(unittest.TestCase):
+    def test_uses_today_delta_when_total_balance_is_stale(self):
+        earned = PointsTracker.calculate_points_earned(
+            start_balance=6305,
+            end_balance=6305,
+            start_today_points=80,
+            end_today_points=110,
+        )
+
+        self.assertEqual(earned, 30)
+
+    def test_uses_balance_delta_when_today_points_are_unavailable(self):
+        earned = PointsTracker.calculate_points_earned(
+            start_balance=6305,
+            end_balance=6315,
+            start_today_points=None,
+            end_today_points=None,
+        )
+
+        self.assertEqual(earned, 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rewards_tasks.py
+++ b/tests/test_rewards_tasks.py
@@ -1,0 +1,93 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import rewards_tasks
+
+
+class FakeRewardsTasks:
+    complete_all_tasks = rewards_tasks.RewardsTaskUtils.complete_all_tasks
+
+    def __init__(self, fail_required=False, enable_mobile=False):
+        self.calls = []
+        self.fail_required = fail_required
+        self.enable_mobile = enable_mobile
+        self.tab_utils = type("Tabs", (), {"close_all_other_tabs": lambda self: None})()
+
+    def _record(self, name):
+        self.calls.append(name)
+
+    def complete_required_searches(self):
+        self._record("Required searches")
+        if self.fail_required:
+            raise rewards_tasks.TimeoutException("breakdown did not open")
+
+    def complete_bing_daily_set(self):
+        self._record("Bing daily set")
+
+    def complete_explore_on_bing_tasks(self):
+        self._record("Explore on Bing")
+
+    def complete_visual_search(self):
+        self._record("Visual search")
+
+    def complete_misc_cards(self):
+        self._record("Misc cards")
+
+    def complete_mobile_searches(self):
+        self._record("Mobile searches")
+
+    def complete_read_to_earn(self):
+        self._record("Read to Earn")
+
+    def claim_bonus_points(self):
+        self._record("Bonus points")
+
+
+class CompleteAllTasksTests(unittest.TestCase):
+    @patch.object(rewards_tasks, "human_idle_delay", lambda *args, **kwargs: None)
+    @patch.object(rewards_tasks.random, "shuffle", lambda items: items.reverse())
+    def test_required_searches_always_run_first(self):
+        fake = FakeRewardsTasks()
+
+        fake.complete_all_tasks()
+
+        self.assertEqual(fake.calls[0], "Required searches")
+
+    @patch.object(rewards_tasks, "human_idle_delay", lambda *args, **kwargs: None)
+    @patch.object(rewards_tasks.random, "shuffle", lambda items: None)
+    def test_returns_skipped_status_for_required_search_timeout(self):
+        fake = FakeRewardsTasks(fail_required=True)
+
+        results = fake.complete_all_tasks()
+
+        self.assertEqual(results["Required searches"], "skipped")
+
+
+    @patch.object(rewards_tasks, "human_idle_delay", lambda *args, **kwargs: None)
+    @patch.object(rewards_tasks.random, "shuffle", lambda items: None)
+    def test_mobile_tasks_run_when_enabled(self):
+        fake = FakeRewardsTasks(enable_mobile=True)
+
+        results = fake.complete_all_tasks()
+
+        self.assertIn("Mobile searches", fake.calls)
+        self.assertIn("Read to Earn", fake.calls)
+        self.assertEqual(results["Read to Earn"], "ok")
+
+    @patch.object(rewards_tasks, "human_idle_delay", lambda *args, **kwargs: None)
+    @patch.object(rewards_tasks.random, "shuffle", lambda items: None)
+    def test_mobile_tasks_absent_when_disabled(self):
+        fake = FakeRewardsTasks(enable_mobile=False)
+
+        fake.complete_all_tasks()
+
+        self.assertNotIn("Mobile searches", fake.calls)
+        self.assertNotIn("Read to Earn", fake.calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
… tracker/gate regressions

- app_rewards.py: Bing/Start app API Read to Earn + Daily Check-In
- browser_lifecycle.py: managed browser session, singleton lock, signal interception
- tab_utils.py: safer tab handling; 15-min anti-cooldown search loops
- points_tracker.py: restore calculate_points_earned (today-delta wins over frozen balance)
- main.py: restore critical_tasks_succeeded gate (exit 1) + --no-cooldown/--no-mobile flags
- rewards_tasks.py: restore required-searches-first + per-task status dict (ok/skipped/failed)
- run.sh: Ollama pre-flight (starts user service, warn on missing model, continue without LLM)
- tests: update FakeRewardsTasks to new contract, add mobile task gating tests (8/8 green)
- gitignore personal data (points_history.json, points_summary.txt) and local backups