### PR TITLE
finish the move on the target instead of a few pixels short

### DIFF
--- a/src/mouse_trajectory.py
+++ b/src/mouse_trajectory.py
@@ -166,9 +166,16 @@ def get_final_path_from_real_time(
 	def final_path_function(t: float) -> Point:
 		if t < 0:
 			return start
-		elif t > movement_time:
+		elif t >= movement_time:
+			# Not just t > movement_time: the sigmoid below is asymptotic, so a
+			# sample taken exactly at movement_time still lands short of the
+			# target and the move has to end here instead.
 			return end
 
+		# 4.5 scales the input just enough to almost reach the target without
+		# distorting the movement velocity. logistic_sigmoid(4.5) is 0.978, not
+		# 1, so this never evaluates the bezier at its endpoint -- that is what
+		# the branch above is for. Revisit both together.
 		normalized_t = (t / movement_time)*4.5
 
 		return path(normalized_t)
@@ -289,8 +296,13 @@ class MouseUtils:
 		)
 		max_x, max_y = int(viewport[0]) - 2, int(viewport[1]) - 2
 
-		while (current_time := time.monotonic()) < end_time:
-			t = current_time - start_time
+		while True:
+			current_time = time.monotonic()
+
+			# Clamped, because the loop is driven by wall clock: without this the
+			# last sample is taken an iteration short of move_time and the pointer
+			# is left short of the target on every move.
+			t = min(current_time - start_time, move_time)
 			point = path_function(t)
 
 			point = (
@@ -309,6 +321,9 @@ class MouseUtils:
 				except JavascriptException: # some uninitialization has happened, reinitialize the cursor visualization
 					self.reinitialize()
 					self.driver.execute_script(f"window.moveVisualCursor({point[0]}, {point[1]});")
+
+			if current_time >= end_time:
+				break
 
 
 	def wheel_scroll_element_into_view(self, element: WebElement, max_wheel_events: int = 60):

--- a/tests/test_mouse_trajectory.py
+++ b/tests/test_mouse_trajectory.py
@@ -1,0 +1,146 @@
+"""Tests for where a simulated move actually leaves the pointer (#74).
+
+The move is driven by two things that both stop short of the target. The path
+normalises elapsed time onto the sigmoid's input range with a 4.5 multiplier,
+and logistic_sigmoid(4.5) is 0.978, so the bezier is never evaluated at its
+endpoint. On top of that move_mouse sampled on the wall clock with a strict
+`< end_time`, so it never asked for a sample at movement_time either. The
+pointer was left a few pixels short of the point move_to_element picked, on
+every move, which costs clicks on the smallest controls and reports nothing
+when it does.
+
+None of them need a browser.
+
+	python -m unittest discover -s tests
+"""
+
+import os
+import random
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import mouse_trajectory
+from mouse_trajectory import (
+	MouseUtils,
+	get_final_path_from_real_time,
+	logistic_sigmoid,
+)
+
+# Long enough to take several samples, short enough that the suite stays quick.
+BRIEF_MOVE = 0.05
+
+
+class RecordingActionBuilder:
+	"""Stands in for ActionBuilder and keeps every location it is asked for."""
+
+	def __init__(self, driver, duration=0):
+		self.locations = driver.locations
+		self.pointer_action = self
+
+	def move_to_location(self, x, y):
+		self._pending = (x, y)
+		return self
+
+	def perform(self):
+		self.locations.append(self._pending)
+
+
+class FakeMouseDriver:
+	"""Answers the one script move_mouse runs and records nothing else."""
+
+	def __init__(self):
+		self.locations = []
+
+	def execute_script(self, script, *args):
+		if "innerWidth" in script:
+			return [1920, 1080]
+
+		return None
+
+
+def make_mouse_utils(driver):
+	"""A MouseUtils without the cursor visualization its __init__ injects."""
+	mouse = MouseUtils.__new__(MouseUtils)
+	mouse.driver = driver
+	mouse.fallback_init_pos = (0, 0)
+
+	return mouse
+
+
+class PathEndsOnTheTarget(unittest.TestCase):
+	def test_a_sample_at_movement_time_is_the_target(self):
+		random.seed(7)
+		start, end = (100, 100), (400, 300)
+		path = get_final_path_from_real_time(1.0, start, end)
+
+		self.assertEqual(path(1.0), end)
+
+	def test_a_sample_before_the_end_still_follows_the_path(self):
+		"""The endpoint must come from reaching the end, not from short-circuiting."""
+		random.seed(7)
+		start, end = (100, 100), (400, 300)
+		path = get_final_path_from_real_time(1.0, start, end)
+
+		midpoint = path(0.5)
+
+		self.assertNotEqual(midpoint, end)
+		self.assertNotEqual(midpoint, start)
+
+	def test_the_sigmoid_alone_does_not_reach_the_end(self):
+		"""Why the branch above exists. If 4.5 ever changes, this says what it cost."""
+		self.assertLess(logistic_sigmoid(4.5), 1.0)
+		self.assertAlmostEqual(logistic_sigmoid(4.5), 0.978026, places=6)
+
+
+class MoveMouseLandsOnTheTarget(unittest.TestCase):
+	def setUp(self):
+		self._real_builder = mouse_trajectory.ActionBuilder
+		mouse_trajectory.ActionBuilder = RecordingActionBuilder
+
+	def tearDown(self):
+		mouse_trajectory.ActionBuilder = self._real_builder
+
+	def test_the_last_move_is_to_the_target(self):
+		random.seed(11)
+		driver = FakeMouseDriver()
+		mouse = make_mouse_utils(driver)
+
+		start, end = (200, 200), (600, 450)
+		path = get_final_path_from_real_time(BRIEF_MOVE, start, end)
+
+		mouse.move_mouse(BRIEF_MOVE, path, visualize=False)
+
+		self.assertEqual(driver.locations[-1], end)
+
+	def test_the_move_is_sampled_along_the_way_not_jumped(self):
+		random.seed(11)
+		driver = FakeMouseDriver()
+		mouse = make_mouse_utils(driver)
+
+		start, end = (200, 200), (600, 450)
+		path = get_final_path_from_real_time(BRIEF_MOVE, start, end)
+
+		mouse.move_mouse(BRIEF_MOVE, path, visualize=False)
+
+		self.assertGreater(len(driver.locations), 1)
+		self.assertNotEqual(driver.locations[0], end)
+
+	def test_a_move_with_no_time_left_still_lands_on_the_target(self):
+		"""A zero-length move must not leave the pointer wherever it started."""
+		random.seed(11)
+		driver = FakeMouseDriver()
+		mouse = make_mouse_utils(driver)
+
+		start, end = (200, 200), (600, 450)
+		path = get_final_path_from_real_time(0.0, start, end)
+
+		mouse.move_mouse(0.0, path, visualize=False)
+
+		self.assertTrue(driver.locations, "the pointer was never moved at all")
+		self.assertEqual(driver.locations[-1], end)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Closes #74.

You asked for the loop's last iteration to be clamped to `movement_time`, with the second solution only if that did not fix it on its own. It does not, so this does both.

### What the clamp alone is worth

Simulated the way #74 was measured: 6000 moves per row, 200px travel, the repo's own path functions, and the same seeds across all three variants so only the sampling differs.

| variant | median offset | p95 | outside a 10x10 control |
| --- | --- | --- | --- |
| today | 2.82px | 5.76px | 13.02% |
| clamp only | 2.77px | 5.65px | 12.22% |
| clamp + path ends on the target | 0.00px | 0.00px | 0.00% |

The harness reproduces #74's published table first (2.82px / 13.02% here against 2.9px / 13.2% filed), so it is measuring the same thing.

Clamping recovers 0.05px of a 2.8px offset. The loop was only ever about one iteration short of `movement_time`, roughly 10ms, and `logistic_sigmoid` barely moves over that span. Nearly all of the shortfall is the 0.978 itself.

### What is in the diff

`move_mouse` clamps its last sample to `move_time`. That is your preferred fix, and it is also what makes the branch below reachable at all.

`final_path_function` returns the endpoint at `t >= movement_time` rather than only `t > movement_time`. That is the second solution, the short linear segment you said would not matter at that distance. It sits in the path function rather than in `move_mouse` because `move_mouse` only receives a path function and does not know where the move was aimed.

The `4.5` is commented with the 0.978 figure and a note that the two are only correct together.

### One thing the tests turned up

With a `move_time` of 0 the old loop body never ran, so `move_mouse` performed no pointer move at all and left the pointer where it started. The clamped loop always takes at least one sample.

### Verification

Full suite 77 passed, 1 skipped, up from 71 and 1. Reverting only `src/mouse_trajectory.py` and keeping the new tests fails exactly 3 of the 6, and the other 71 pass either way. Re-measured against the patched module rather than the model: 6000 trials at 10x10, median offset 0.0000px, max 0.0000px, 0% outside.

### Worth flagging

`t >= movement_time` short-circuits for any caller of `get_final_path_from_real_time`, not only `move_mouse`. There is one caller today, but it is a behaviour change rather than a pure bugfix. #78 touches the same module, so this will want a rebase if that lands first.
